### PR TITLE
Adds support for batching API calls.

### DIFF
--- a/lib/Router.js
+++ b/lib/Router.js
@@ -376,13 +376,23 @@ Router.prototype.middleware = function(options) {
             return respondDocs.call(this, res);
         }
 
-        var connection = new Connection(this, req, res);
+        var path = req.url.substr(basePathLength).replace(/\?.*/, '');
 
+        // Support batch
+        if ('/_batch' === path && 'POST' === req.method) {
+            this.batch(req, res)
+            .then(function(results) {
+                respondJson(res, results);
+            });
+            return;
+        }
+
+        var connection = new Connection(this, req, res);
         var request = new Request(req.url);
         var parsedUrl = request.getUrl();
         request.setMethod(req.method);
 
-        request.setResourceId(req.url.substr(basePathLength).replace(/\?.*/, ''));
+        request.setResourceId(path);
 
         if (req.body) {
             request.setResource(req.body);
@@ -398,4 +408,33 @@ Router.prototype.middleware = function(options) {
             });
         }.bind(this));
     }.bind(this);
+};
+
+Router.prototype.batch = function(req, res) {
+    var connection = new Connection(this, req, res);
+
+    return Promise.all(req.body.map(function(envelope) {
+        var request = new Request(envelope.url);
+        var parsedUrl = request.getUrl();
+        request.setMethod(envelope.method);
+        request.setResourceId(parsedUrl.pathname);
+
+        if (envelope.body) {
+            request.setResource(envelope.body);
+        }
+
+        return this.handle(request, connection)
+        .then(function(result) {
+            return {
+                status: 200,
+                body: result
+            };
+        })
+        .catch(function(error) {
+            return {
+                status: 404,
+                body: error
+            };
+        });
+    }.bind(this)));
 };


### PR DESCRIPTION
To batch API calls, make a `POST` request to `/_batch` with an array of request objects. The request objects contain the following pieces of data:
- **`url`**: The url to the resource, without basepath prefix. e.g. `/users/123`. Special query string parameters like `props` can be appended to the url.
- **`method`**: The HTTP method to use, e.g. `GET`, `POST`, `PATCH`, etc.
- **`body`**: Optional resource body, used primarily by `POST`, `PUT`, and `PATCH` requests.

Monocle will loop over the requests and process them concurrently. The response will contain an array of the results. Each item in the array will be mapped to the request based on array index. Each item will contain HTTP status code and response body.

**Sample using curl**

```
$ curl -H "Content-Type: application/json" -d '[{"url": "/users/1?props=displayName,age", "method": "GET"}, {"url": "/users/2?props=gender,city", "method": "GET"}, {"url": "/users/3?props=displayName", "method": "PUT", "body": {"displayName": "Joe Mama"}}]' -i http://localhost:5150/my-api/_batch
HTTP/1.1 200 OK
Content-Type: application/json
Date: Tue, 06 Oct 2015 19:01:13 GMT
Connection: keep-alive
Transfer-Encoding: chunked

[
  {
    "status": 200,
    "body": {
      "displayName": "Alice",
      "age": 27,
      "$id": "/users/1",
      "$expires": 3600
    }
  },
  {
    "status": 200,
    "body": {
      "gender": "M",
      "city": "San Jose",
      "$id": "/users/2",
      "$expires": 3600
    }
  },
  {
    "status": 200,
    "body": {
      "displayName": "Joe Mama",
      "$id": "/users/3",
      "$expires": 3600
    }
  }
]
```
