### PR TITLE
Ignore `props` if http status is non-2XX

### DIFF
--- a/lib/Router.js
+++ b/lib/Router.js
@@ -241,32 +241,15 @@ Router.prototype.handle = function(request, connection) {
         // Merges results from different functions
         var result = _.merge.apply(null, results);
 
-        var props = request.getProps();
+        // Restrict by props if httpStatus is 2XX
+        if (!result.hasOwnProperty('$httpStatus') || (result.$httpStatus >= 200 && result.$httpStatus < 300)) {
+            result = restrictProps(result, request.getProps());
+        }
 
-        if (props.length) {
-            // Remove all unneeded props
-            for (var i in result) {
-                if (!result.hasOwnProperty(i)) continue;
-                if (i[0] === '$') continue;
-                if (-1 === props.indexOf(i)) delete result[i];
-            }
-
-            props.forEach(function(prop) {
-                if (result.hasOwnProperty(prop)) return;
-
-                // Check if param can be reflected from request
-                var reflectedParam = request.getParam(prop);
-                if (reflectedParam) result[prop] = reflectedParam;
-            });
-
-            var unfound = props.filter(function(prop) {
-                return !result.hasOwnProperty(prop);
-            });
-
-            if (unfound.length) {
-                emit.call(this, 'api:error', request, route, timeStart);
-                return Promise.reject("Unable to resolve props " + unfound.join(', ') + " for resource " + resourceId);
-            }
+        // Support internal errors
+        if (result.$internalError == 'missing') {
+            emit.call(this, 'api:error', request, route, timeStart);
+            return Promise.reject("Unable to resolve props " + result.unfound.join(', ') + " for resource " + resourceId);
         }
 
         // Resolve symlinks
@@ -295,6 +278,32 @@ Router.prototype.handle = function(request, connection) {
 
     }.bind(this));
 };
+
+var restrictProps = function(resource, props) {
+    if (!props || !props.length) {
+        return resource;
+    }
+
+    // Remove all unneeded props
+    for (var i in resource) {
+        if (!resource.hasOwnProperty(i)) continue;
+        if (i[0] === '$') continue;
+        if (-1 === props.indexOf(i)) delete resource[i];
+    }
+
+    var unfound = props.filter(function(prop) {
+        return !resource.hasOwnProperty(prop);
+    });
+
+    if (unfound.length) {
+        return {
+            $internalError: 'missing',
+            unfound: unfound
+        };
+    }
+
+    return resource;
+}
 
 var emit = function(event, request, route, timeStart, extraData) {
     data = extraData || {};


### PR DESCRIPTION
If a route responds with a non-2XX response, skip props filtering to allow errors to pass through.
