### PR TITLE
Adds support for responding with errors.

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -22,7 +22,7 @@ function Connection(router, req, res) {
     Request.METHOD_OPTIONS
 ].forEach(function(method) {
     Connection.prototype[method.toLowerCase()] = function (resourceId, options) {
-        var request = new Request(resourceId);
+        var request = new Request(resourceId, this.router, this);
         request.setResourceId(resourceId);
         request.setMethod(method);
 

--- a/lib/HttpStatusCodes.js
+++ b/lib/HttpStatusCodes.js
@@ -1,0 +1,86 @@
+function HttpStatusCodes() {
+    this._statuses = {
+        // 1xx
+        '100': 'CONTINUE',
+        '101': 'SWITCHING PROTOCOLS',
+        '102': 'PROCESSING',
+
+        // 2xx
+        '200': 'OK',
+        '201': 'CREATED',
+        '202': 'ACCEPTED',
+        '203': 'NON-AUTHORITATIVE INFORMATION',
+        '204': 'NO CONTENT',
+        '205': 'RESET CONTENT',
+        '206': 'PARTIAL CONTENT',
+        '207': 'MULTI-STATUS',
+
+        // 3xx
+        '300': 'MULTIPLE CHOICES',
+        '301': 'MOVED PERMANENTLY',
+        '302': 'FOUND',
+        '303': 'SEE OTHER',
+        '304': 'NOT MODIFIED',
+        '305': 'USE PROXY',
+        '306': 'SWITCH PROXY',
+        '307': 'TEMPORARY REDIRECT',
+        '308': 'PERMANENT REDIRECT',
+
+        // 4xx
+        '400': 'BAD REQUEST',
+        '401': 'UNAUTHORIZED',
+        '402': 'PAYMENT REQUIRED',
+        '403': 'FORBIDDEN',
+        '404': 'NOT FOUND',
+        '405': 'METHOD NOT ALLOWED',
+        '406': 'NOT ACCEPTABLE',
+        '407': 'PROXY AUTHENTICATION REQUIRED',
+        '408': 'REQUEST TIMEOUT',
+        '409': 'CONFLICT',
+        '410': 'GONE',
+        '411': 'LENGTH REQUIRED',
+        '412': 'PRECONDITION FAILED',
+        '413': 'PAYLOAD TOO LARGE',
+        '414': 'URI TOO LONG',
+        '415': 'UNSUPPORTED MEDIA TYPE',
+        '416': 'RANGE NOT SATISFIABLE',
+        '417': 'EXPECTATION FAILED',
+        '418': 'I\'M A TEAPOT',
+        '419': 'AUTHENTICATION TIMEOUT',
+        '421': 'MISDIRECTED REQUEST',
+        '422': 'UNPROCESSABLE ENTITY',
+        '423': 'LOCKED',
+        '424': 'FAILED DEPENDENCY',
+        '426': 'UPGRADE REQUIRED',
+        '428': 'PRECONDITION REQUIRED',
+        '429': 'TOO MANY REQUESTS',
+        '431': 'REQUEST HEADER FIELDS TOO LARGE',
+
+        // 5xx
+        '500': 'INTERNAL SERVER ERROR',
+        '501': 'NOT IMPLEMENTED',
+        '502': 'BAD GATEWAY',
+        '503': 'SERVICE UNAVAILABLE',
+        '504': 'GATEWAY TIMEOUT',
+        '505': 'HTTP VERSION NOT SUPPORTED',
+        '506': 'VARIANT ALSO NEGOTIATES',
+        '507': 'INSUFFICIENT STORAGE',
+        '508': 'LOOP DETECTED',
+        '510': 'NOT EXTENDED',
+        '511': 'NETWORK AUTHENTICATION REQUIRED',
+        '520': 'UNKNOWN ERROR',
+        '522': 'ORIGIN CONNECTION TIME-OUT'
+    };
+}
+
+HttpStatusCodes.prototype.lookupByCode = function(code) {
+    var strCode = (code || '').toString();
+
+    return this._statuses.hasOwnProperty(strCode) ? this._statuses[strCode] : null;
+};
+
+HttpStatusCodes.prototype.getAll = function() {
+    return this._statuses;
+};
+
+module.exports = HttpStatusCodes;

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -4,8 +4,10 @@ var Resource = require('./Resource');
 
 module.exports = Request;
 
-function Request(url) {
+function Request(url, router, connection) {
     this.setUrl(url);
+    this._router = router;
+    this._connection = connection;
     this._params = {};
     this._method = Request.METHOD_GET;
 }
@@ -122,8 +124,42 @@ Request.prototype.getResourceId = function() {
 Request.prototype.setResource = function(resource) {
     this._resource = resource;
     return this;
-}
+};
 
 Request.prototype.getResource = function() {
     return this._resource;
-}
+};
+
+Request.prototype.error = function(httpStatusCode, message) {
+    return this._router.error(httpStatusCode, message);
+};
+
+Request.prototype.propertyError = function(property, errorCode, httpStatusCode, message) {
+    httpStatusCode = parseInt(httpStatusCode, 10) || 400;
+    var httpErrorString = this._router._httpStatusCodes.lookupByCode(httpStatusCode);
+    var properties = [];
+
+    return this._connection.options(this._resourceId)
+    .then(function(options) {
+        if (options.schema.properties.hasOwnProperty(property)) {
+            // Get details about the error code
+            var error = options.schema.properties[property].errorCodes.filter(function(item) {
+                return item.code == errorCode;
+            })[0];
+
+            properties.push({
+                property: property,
+                code: error.code,
+                error: error.error,
+                message: error.message
+            });
+        }
+
+        return this._router.status(httpStatusCode, {
+            code: httpStatusCode,
+            error: httpErrorString,
+            message: message,
+            properties: properties
+        });
+    }.bind(this));
+};

--- a/lib/Router.js
+++ b/lib/Router.js
@@ -7,13 +7,15 @@ var validateSchema = jsen({"$ref": "http://json-schema.org/draft-04/schema#"});
 var Request = require('./Request');
 var Connection = require('./Connection');
 var Symlink = require('./Symlink');
-
 var util = require('util');
+var HttpStatusCodes = require('./HttpStatusCodes');
+var errorSchema = require('./schemas/error');
 
 module.exports = Router;
 
 function Router() {
     this._routes = [];
+    this._httpStatusCodes = new HttpStatusCodes();
 }
 
 // Extend EventEmitter
@@ -73,6 +75,34 @@ var titleCompare = function(a, b) {
     return (a.schema.title || a.pattern) > (b.schema.title || b.pattern);
 };
 
+Router.prototype.error = function(httpStatusCode, message) {
+    var error = this._httpStatusCodes.lookupByCode(httpStatusCode);
+
+    return this.status(httpStatusCode, {
+        code: parseInt(httpStatusCode, 10),
+        error: error,
+        message: message || 'Unknown error',
+        properties: []
+    });
+};
+
+Router.prototype.propertyError = function(property, errorCode, httpStatusCode) {
+    httpStatusCode = parseInt(httpStatusCode, 10) || 400;
+    var httpErrorString = this._httpStatusCodes.lookupByCode(httpStatusCode);
+    var properties = [];
+
+    console.log('property', property);
+
+
+
+    return this.status(httpStatusCode, {
+        code: httpStatusCode,
+        error: httpErrorString,
+        message: 'Unknown error',
+        properties: properties
+    });
+};
+
 Router.prototype.documentAll = function() {
     return Promise.map(this._routes, documentRoute)
     .then(sortByTitle);
@@ -114,7 +144,11 @@ function documentRoute(route) {
 Router.prototype.status = function(code, body) {
     body = body || {};
     body.$httpStatus = parseInt(code, 10);
-    return Promise.resolve(body);
+    if (code >= 200 && code < 300) {
+        return Promise.resolve(body);
+    } else {
+        return Promise.reject(body);
+    }
 }
 
 function getMatchedRoute(resourceId) {
@@ -275,9 +309,20 @@ Router.prototype.handle = function(request, connection) {
 
             return result;
         }.bind(this))
+    }.bind(this))
+    .catch(function(error) {
+        // Validate error
+        var validate = jsen(errorSchema);
+        var valid = validate(error);
 
+        if (!valid) {
+            // Error response must validate with error schema
+            return this.error(500, 'Error response did not validate with schema');
+        }
 
-    }.bind(this));
+        // Forward error
+        return Promise.reject(error);
+    });
 };
 
 var restrictProps = function(resource, props) {
@@ -422,7 +467,7 @@ Router.prototype.middleware = function(options) {
         }
 
         var connection = new Connection(this, req, res);
-        var request = new Request(req.url);
+        var request = new Request(req.url, this, connection);
         var parsedUrl = request.getUrl();
         request.setMethod(req.method);
 
@@ -448,7 +493,7 @@ Router.prototype.batch = function(req, res) {
     var connection = new Connection(this, req, res);
 
     return Promise.all(req.body.map(function(envelope) {
-        var request = new Request(envelope.url);
+        var request = new Request(envelope.url, this, connection);
         var parsedUrl = request.getUrl();
         request.setMethod(envelope.method);
         request.setResourceId(parsedUrl.pathname);

--- a/lib/schemas/error.js
+++ b/lib/schemas/error.js
@@ -1,0 +1,57 @@
+module.exports = {
+    type: 'object',
+    properties: {
+        code: {
+            type: 'integer',
+            description: 'HTTP status code.',
+            sample: 403,
+            required: true
+        },
+        error: {
+            type: 'string',
+            description: 'String representation of HTTP status code.',
+            sample: 'FORBIDDEN',
+            required: true
+        },
+        message: {
+            type: 'string',
+            description: 'General description of the error.',
+            sample: 'Unable to update user id 123',
+            required: true
+        },
+        properties: {
+            type: 'array',
+            description: 'Array of properties in error. If no individual properties are in error, this will be an empty array.',
+            require: true,
+            items: {
+                type: 'object',
+                properies: {
+                    property: {
+                        type: 'string',
+                        description: 'Property name relative to document root. Nested properties will be dot-separated.',
+                        sample: 'primaryPhoto.caption',
+                        required: true
+                    },
+                    code: {
+                        type: 'integer',
+                        description: 'Error code.',
+                        sample: 1029,
+                        required: true
+                    },
+                    error: {
+                        type: 'string',
+                        description: 'Error in string format.',
+                        sample: 'TOO_SHORT',
+                        required: true
+                    },
+                    message: {
+                        type: 'string',
+                        description: 'Description of the error message for this field.',
+                        sample: 'Photo caption contains banned content.',
+                        required: true
+                    }
+                }
+            }
+        }
+    }
+};


### PR DESCRIPTION
**New interfaces to support error handling:**

To respond with a general error about the resource as a whole, use:

```
return request.error(httpStatusCode, message);
```

If a single property is in error, then use:

```
return request.propertyError(propertyName, errorCode, httpStatusCode, message);
```

The error codes can be added to the resource schemas, ensuring they are always documented.

**Breaking Changes**
- All non-2xx responses are validated with the `Error` schema. In the event that a non-2xx status code was generated with an invalid body, then a `500` error will be returned.
