### PR TITLE
Adds support to fetch nested properties from objects and arrays.

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -9,6 +9,7 @@ var _ = require('lodash');
 var Promise = require('bluebird');
 var Router = require('../lib');
 var Resource = require('../lib').Resource;
+var Symlink = require('../lib').Symlink;
 
 /*** Set up simple HTTP server ***/
 
@@ -76,16 +77,11 @@ api.route('/users/:userId', userSchema, {
 
 // Defines the route that manages a collection of users
 api.route('/users', userCollectionSchema, {
-    get: [
-        {
-            props: ['displayName', 'age', 'gender', 'city', 'country'],
-            callback: getUsersBasicInfo
-        },
-        {
-            props: ['email'],
-            callback: getUsersEmailInfo
-        }
-    ],
+    get: function(request, connection) {
+        return mockUserEmails.map(function(user) {
+            return new Symlink('/users/' + user.userId);
+        });
+    },
     post: createUser
 });
 

--- a/lib/PropertyFilter.js
+++ b/lib/PropertyFilter.js
@@ -1,0 +1,93 @@
+var PropertyFilter = function(data) {
+    this._data = data;
+};
+
+PropertyFilter.prototype.props = function(props) {
+    if (!props || !props.length) {
+        return this._data;
+    }
+
+    // Ignore symlinks -- they can't be filtered yet.
+    if (this._data.hasOwnProperty('$link')) {
+        return this._data;
+    }
+
+    if (Array.isArray(this._data)) {
+        props = props.map(function(prop) {
+            return (prop[0] === '@') ? prop.substr(1) : prop;
+        });
+
+        return this._data.map(function(data) {
+            var filter = new PropertyFilter(data);
+            return filter.props(props);
+        });
+    }
+
+    var filtered = {};
+
+    // Always keep properties that begin with `$`
+    for (var key in this._data) {
+        if (this._data.hasOwnProperty(key) && key[0] == '$') {
+            filtered[key] = this._data[key];
+        }
+    }
+
+    // Keep track of nested and plucked properties
+    var nested = {};
+
+    // Populate filtered object with properties we want to keep
+    var missing = [];
+
+    props.forEach(function(prop) {
+        // Directly assign top-level props
+        if (-1 === prop.indexOf('.') && -1 === prop.indexOf('@')) {
+            if (!this._data.hasOwnProperty(prop)) {
+                missing.push(prop);
+            } else {
+                filtered[prop] = this._data[prop];
+            }
+
+            return;
+        }
+
+        // Nested or plucked props, aggregate them for later
+        var path = prop.split('.');
+        var key = path.shift();
+
+        if (-1 !== key.indexOf('@')) {
+            // Attempting to pluck from an array
+            var parts = key.split('@');
+            key = parts.shift();
+            nested[key] = nested[key] || [];
+            nested[key].push(parts.join('@'));
+        } else {
+            // Normal nested property
+            nested[key] = nested[key] || [];
+            nested[key].push(path.join('.'));
+        }
+    }.bind(this));
+
+    if (missing.length) {
+        return missingError(missing);
+    }
+
+    // Recursively handle the nested/plucked props
+    for (var prop in nested) {
+        if (!this._data.hasOwnProperty(prop)) {
+            return missingError([prop]);
+        }
+        var filter = new PropertyFilter(this._data[prop]);
+        filtered[prop] = filter.props(nested[prop], true);
+    }
+
+    return filtered;
+};
+
+function missingError(missing) {
+    return {
+        $error: "One or more properties missing from data",
+        $missing: missing
+    };
+}
+
+module.exports = PropertyFilter;

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -5,5 +5,5 @@ module.exports = Resource;
 function Resource(id, data, expires) {
     this.$id = id;
     this.$expires = parseInt(expires, 10) || 0;
-    _.merge(this, data || {});
+    return _.merge(this, data || {});
 }

--- a/lib/Router.js
+++ b/lib/Router.js
@@ -7,10 +7,12 @@ var validateSchema = jsen({"$ref": "http://json-schema.org/draft-04/schema#"});
 var Request = require('./Request');
 var Connection = require('./Connection');
 var Symlink = require('./Symlink');
+var PropertyFilter = require('./PropertyFilter');
 var util = require('util');
 var HttpStatusCodes = require('./HttpStatusCodes');
 var errorSchema = require('./schemas/error');
 var validationErrors = require('./models/validationErrors');
+var Resource = require('./Resource');
 
 module.exports = Router;
 
@@ -235,7 +237,10 @@ Router.prototype.handle = function(request, connection) {
 
         if (props.length) {
             route.handlers[method].filter(function(handler) {
-                return _.intersection(request.getProps(), handler.props).length;
+                var topLevelProps = props.map(function(prop) {
+                    return prop.split('.')[0];
+                });
+                return _.intersection(topLevelProps, handler.props).length;
             }).forEach(function(handler) {
                 handlers.push(handler.callback);
             });
@@ -291,21 +296,23 @@ Router.prototype.handle = function(request, connection) {
             // Multiple resources returned
             if (_.isArray(result)) {
                 return result.map(function(r) {
-                    // Convert to an object
-                    return _.merge({}, r);
+                    // Convert to an object if an instance
+                    return (_.isObject(r)) ? _.merge({}, r) : r;
                 });
+            } else if (_.isObject(result)) {
+                return _.merge({}, result);
             }
 
             return result;
         });
 
         // Merges results from different functions
-        var result = _.merge.apply(null, results);
+        var result = _.merge.apply(null, results.concat([function Customizer(a, b) {
+            if (a instanceof Resource || b instanceof Resource) {
+                return _.merge(a, b);
+            }
+        }]));
 
-        // Restrict by props if httpStatus is 2XX
-        if (!result.hasOwnProperty('$httpStatus') || (result.$httpStatus >= 200 && result.$httpStatus < 300)) {
-            result = restrictProps(result, request.getProps());
-        }
 
         // Support internal errors
         if (result.$internalError == 'missing') {
@@ -313,8 +320,16 @@ Router.prototype.handle = function(request, connection) {
             return Promise.reject("Unable to resolve props " + result.unfound.join(', ') + " for resource " + resourceId);
         }
 
+        var props = request.getProps();
+
+        // Restrict by props before resolving symlinks to delete symlinks that are not needed.
+        result = restrictProps(result, props);
+
         // Resolve symlinks
-        return resolveSymlinks(result, connection).then(function() {
+        return resolveSymlinks(result, connection, props).then(function() {
+            // Now that all symlinks are resolved, restrict again
+            result = restrictProps(result, props);
+
             // Validate responses except for DELETE methods
             if (!result.$httpStatus && method !== Request.METHOD_DELETE) {
                 var validate = jsen(route.schema);
@@ -366,29 +381,21 @@ var remove$Props = function(resource) {
 };
 
 var restrictProps = function(resource, props) {
-    if (!props || !props.length) {
+    if (resource.hasOwnProperty('$httpStatus') && (resource.$httpStatus < 200 || resource.$httpStatus >= 300)) {
         return resource;
     }
 
-    // Remove all unneeded props
-    for (var i in resource) {
-        if (!resource.hasOwnProperty(i)) continue;
-        if (i[0] === '$') continue;
-        if (-1 === props.indexOf(i)) delete resource[i];
-    }
+    var filter = new PropertyFilter(resource);
+    var filtered = filter.props(props);
 
-    var unfound = props.filter(function(prop) {
-        return !resource.hasOwnProperty(prop);
-    });
-
-    if (unfound.length) {
+    if (filtered.$error) {
         return {
             $internalError: 'missing',
-            unfound: unfound
+            unfound: filtered.$missing
         };
     }
 
-    return resource;
+    return filtered;
 }
 
 var emit = function(event, request, route, timeStart, extraData) {
@@ -407,28 +414,38 @@ var emit = function(event, request, route, timeStart, extraData) {
 };
 
 // This function handles arrays and objects
-var resolveSymlinks = function(results, connection)
-{
+var resolveSymlinks = function(results, connection, props){
     var promises = [];
+    props = props || [];
 
-    function recurse(results, connection) {
+    function recurse(results, connection, props) {
         for (var key in results) {
-            (function(i) {
+            (function resolveSymlink(i) {
                 value = results[key];
-                if (value instanceof Symlink) {
-                     var promise = value.resolve(connection)
-                        .then(function(result) {
-                            results[i] = result;
-                        });
+
+                if (value.hasOwnProperty('$link')) {
+                    childProps = props.filter(function filterSelfOnly(prop) {
+                        var root = prop.split('.')[0].replace(/#.*$/, '');
+                        return root === key;
+                    }).map(function getRoot(prop) {
+                        return prop.replace(/^.*\./, '');
+                    }).filter(function(prop) {
+                        return prop && prop[0] !== '$' && prop !== key;
+                    });
+
+                    var promise = connection.get(value.$link, { props: childProps })
+                    .then(function(result) {
+                        results[i] = result;
+                    });
                     promises.push(promise);
                 } else if (typeof value == "object" && value !== null) {
-                    recurse(value, connection);
+                    recurse(value, connection, props);
                 }
             })(key);
         }
     }
 
-    recurse(results, connection);
+    recurse(results, connection, props);
 
     return Promise.all(promises);
 }

--- a/lib/Symlink.js
+++ b/lib/Symlink.js
@@ -1,9 +1,9 @@
 module.exports = Symlink;
 
-function Symlink(id) {
-    this.id = id;
+function Symlink(link) {
+    this.$link = link;
 }
 
 Symlink.prototype.resolve = function(connection) {
-    return connection.get(this.id);
+    return connection.get(this.$link);
 }

--- a/test/lib/PropertyFilter_test.js
+++ b/test/lib/PropertyFilter_test.js
@@ -1,0 +1,754 @@
+var PropertyFilter = require('../../lib/PropertyFilter');
+
+describe('PropertyFilter', function() {
+    describe('with simple, one-dimensional object', function() {
+        beforeEach(function() {
+            this.data = {
+                foo: 'test foo',
+                bar: 'test bar',
+                dur: 'test dur',
+                $internal: 'test $internal',
+                $other_internal: 'test $other_internal'
+            };
+            this.filter = new PropertyFilter(this.data);
+        });
+
+        describe('.props()', function() {
+            beforeEach(function() {
+                this.filtered = this.filter.props(['foo', 'bar']);
+            });
+
+            it('returns an object', function() {
+                this.filtered.should.be.an('object');
+            });
+
+            it('keeps specified properties', function() {
+                this.filtered.should.have.property('foo', 'test foo');
+                this.filtered.should.have.property('bar', 'test bar');
+            });
+
+            it('keeps internal properties that start with `$`', function() {
+                this.filtered.should.have.property('$internal', 'test $internal');
+                this.filtered.should.have.property('$other_internal', 'test $other_internal');
+            });
+
+            it('discards unspecified properties', function() {
+                this.filtered.should.not.have.property('dur');
+            });
+
+            it('returns error object if requested property does not exist', function() {
+                this.filter.props(['unknown']).should.have.property('$error');
+            });
+
+            it('returns data unchanged if no properties are specified', function() {
+                this.filter.props().should.deep.equal(this.data); // no argument
+                this.filter.props([]).should.deep.equal(this.data); // empty array
+            });
+        });
+    });
+
+    describe('with multi-dimensional object', function() {
+        beforeEach(function() {
+            this.data = {
+                $id: 1,
+                foo: 'test foo',
+                bar: 'test bar',
+                dur: 'test dur',
+                child: {
+                    $id: 2,
+                    foo: 'test child foo',
+                    bar: 'test child bar',
+                    dur: 'test child dur',
+                    grandchild: {
+                        $id: 3,
+                        foo: 'test grandchild foo',
+                        bar: 'test grandchild bar',
+                        dur: 'test grandchild dur'
+                    }
+                }
+            };
+            this.filter = new PropertyFilter(this.data);
+        });
+
+        describe('.props()', function() {
+            describe('top-level props', function() {
+                beforeEach(function() {
+                    this.filtered = this.filter.props(['foo', 'bar', 'child']);
+                });
+
+                it('returns an object', function() {
+                    this.filtered.should.be.an('object');
+                });
+
+                it('keeps specified properties', function() {
+                    this.filtered.should.have.property('foo', 'test foo');
+                    this.filtered.should.have.property('bar', 'test bar');
+                    this.filtered.should.have.property('child');
+                });
+
+                it('does not clobber child objects', function() {
+                    this.filtered.child.should.deep.equal(this.data.child);
+                });
+
+                it('keeps internal properties that start with `$`', function() {
+                    this.filtered.should.have.property('$id', 1);
+                    this.filtered.child.should.have.property('$id', 2);
+                    this.filtered.child.grandchild.should.have.property('$id', 3);
+                });
+
+                it('discards unspecified properties', function() {
+                    this.filtered.should.not.have.property('dur');
+                });
+            });
+
+            describe('nested props', function() {
+                beforeEach(function() {
+                    this.filtered = this.filter.props([
+                        'foo',
+                        'child.foo',
+                        'child.bar',
+                        'child.grandchild.bar',
+                        'child.grandchild.dur'
+                    ]);
+                });
+
+                it('returns an object', function() {
+                    this.filtered.should.be.an('object');
+                });
+
+                it('keeps specified properties', function() {
+                    this.filtered.should.have.property('foo', 'test foo');
+                    this.filtered.should.have.property('child');
+                    this.filtered.child.should.have.property('foo');
+                    this.filtered.child.should.have.property('bar');
+                    this.filtered.child.should.have.property('grandchild');
+                    this.filtered.child.grandchild.should.have.property('dur', 'test grandchild dur');
+                });
+
+                it('keeps nested internal properties that start with `$`', function() {
+                    this.filtered.should.have.property('$id', 1);
+                    this.filtered.child.should.have.property('$id', 2);
+                    this.filtered.child.grandchild.should.have.property('$id', 3);
+                });
+
+                it('discards unspecified properties', function() {
+                    this.filtered.should.not.have.property('bar');
+                    this.filtered.should.not.have.property('dur');
+                    this.filtered.child.should.not.have.property('dur');
+                    this.filtered.child.grandchild.should.not.have.property('foo');
+                });
+            });
+        });
+    });
+
+    describe('with multi-dimensional object containing symlinks', function() {
+        beforeEach(function() {
+            this.data = {
+                $id: 1,
+                foo: 'test foo',
+                bar: 'test bar',
+                dur: 'test dur',
+                child1: { $link: '/parent/child1' },
+                child2: { $link: '/parent/child2' },
+            };
+            this.filter = new PropertyFilter(this.data);
+        });
+
+        describe('.props()', function() {
+            describe('top-level props', function() {
+                beforeEach(function() {
+                    this.filtered = this.filter.props(['foo', 'bar', 'child1']);
+                });
+
+                it('returns an object', function() {
+                    this.filtered.should.be.an('object');
+                });
+
+                it('keeps specified properties', function() {
+                    this.filtered.should.have.property('foo', 'test foo');
+                    this.filtered.should.have.property('bar', 'test bar');
+                    this.filtered.should.have.property('child1');
+                });
+
+                it('does not clobber symlink', function() {
+                    this.filtered.child1.should.deep.equal(this.data.child1);
+                });
+
+                it('keeps internal properties that start with `$`', function() {
+                    this.filtered.should.have.property('$id', 1);
+                    this.filtered.child1.should.have.property('$link', '/parent/child1');
+                });
+
+                it('discards unspecified properties', function() {
+                    this.filtered.should.not.have.property('dur');
+                    this.filtered.should.not.have.property('child2');
+                });
+            });
+
+            describe('nested props', function() {
+                beforeEach(function() {
+                    this.filtered = this.filter.props([
+                        'foo',
+                        'child1.foo',
+                        'child1.bar',
+                        'child1.grandchild.bar',
+                        'child1.grandchild.dur'
+                    ]);
+                });
+
+                it('returns an object', function() {
+                    this.filtered.should.be.an('object');
+                });
+
+                it('keeps specified properties that are not symlinked', function() {
+                    this.filtered.should.have.property('foo', 'test foo');
+                    this.filtered.should.have.property('child1');
+                });
+
+                it('keeps nested internal properties that start with `$`', function() {
+                    this.filtered.should.have.property('$id', 1);
+                    this.filtered.child1.should.have.property('$link', '/parent/child1');
+                });
+
+                it('discards unspecified properties', function() {
+                    this.filtered.should.not.have.property('bar');
+                    this.filtered.should.not.have.property('dur');
+                    this.filtered.should.not.have.property('child2');
+                });
+            });
+        });
+    });
+
+    describe('with array of simple, one-dimensional objects', function() {
+        beforeEach(function() {
+            this.data = [
+                {
+                    foo: 'test foo 1',
+                    bar: 'test bar 1',
+                    dur: 'test dur 1',
+                    $internal: 'test $internal 1',
+                    $other_internal: 'test $other_internal 1'
+                },
+                {
+                    foo: 'test foo 2',
+                    bar: 'test bar 2',
+                    dur: 'test dur 2',
+                    $internal: 'test $internal 2',
+                    $other_internal: 'test $other_internal 2'
+                },
+                {
+                    foo: 'test foo 3',
+                    bar: 'test bar 3',
+                    dur: 'test dur 3',
+                    $internal: 'test $internal 3',
+                    $other_internal: 'test $other_internal 3'
+                }
+            ];
+            this.filter = new PropertyFilter(this.data);
+        });
+
+        describe('.props()', function() {
+            beforeEach(function() {
+                this.filtered = this.filter.props(['@foo', '@bar']);
+            });
+
+            it('returns an array', function() {
+                this.filtered.should.be.an('array');
+            });
+
+            it('keeps specified properties', function() {
+                this.filtered[0].should.have.property('foo', 'test foo 1');
+                this.filtered[0].should.have.property('bar', 'test bar 1');
+                this.filtered[1].should.have.property('foo', 'test foo 2');
+                this.filtered[1].should.have.property('bar', 'test bar 2');
+                this.filtered[2].should.have.property('foo', 'test foo 3');
+                this.filtered[2].should.have.property('bar', 'test bar 3');
+            });
+
+            it('keeps internal properties that start with `$`', function() {
+                this.filtered[0].should.have.property('$internal', 'test $internal 1');
+                this.filtered[0].should.have.property('$other_internal', 'test $other_internal 1');
+                this.filtered[1].should.have.property('$internal', 'test $internal 2');
+                this.filtered[1].should.have.property('$other_internal', 'test $other_internal 2');
+                this.filtered[2].should.have.property('$internal', 'test $internal 3');
+                this.filtered[2].should.have.property('$other_internal', 'test $other_internal 3');
+            });
+
+            it('discards unspecified properties', function() {
+                this.filtered[0].should.not.have.property('dur');
+                this.filtered[1].should.not.have.property('dur');
+                this.filtered[1].should.not.have.property('dur');
+            });
+        });
+    });
+
+    describe('with array of multi-dimensional object', function() {
+        beforeEach(function() {
+            function createObject(id) {
+                return {
+                    $id: 'test id ' + id,
+                    foo: 'test foo ' + id,
+                    bar: 'test bar ' + id,
+                    dur: 'test dur ' + id,
+                    child: {
+                        $id: 'test child id ' + id,
+                        foo: 'test child foo ' + id,
+                        bar: 'test child bar ' + id,
+                        dur: 'test child dur ' + id,
+                        grandchild: {
+                            $id: 'test grandchild id ' + id,
+                            foo: 'test grandchild foo ' + id,
+                            bar: 'test grandchild bar ' + id,
+                            dur: 'test grandchild dur ' + id
+                        }
+                    }
+                };
+            };
+
+            this.data = [
+                createObject(1),
+                createObject(2),
+                createObject(3)
+            ];
+
+            this.filter = new PropertyFilter(this.data);
+        });
+
+        describe('.props()', function() {
+            describe('top-level props', function() {
+                beforeEach(function() {
+                    this.filtered = this.filter.props(['@foo', '@bar', '@child']);
+                });
+
+                it('returns an array', function() {
+                    this.filtered.should.be.an('array');
+                });
+
+                it('keeps specified properties', function() {
+                    this.filtered[0].should.have.property('foo', 'test foo 1');
+                    this.filtered[0].should.have.property('bar', 'test bar 1');
+                    this.filtered[0].should.have.property('child');
+
+                    this.filtered[1].should.have.property('foo', 'test foo 2');
+                    this.filtered[1].should.have.property('bar', 'test bar 2');
+                    this.filtered[1].should.have.property('child');
+
+                    this.filtered[2].should.have.property('foo', 'test foo 3');
+                    this.filtered[2].should.have.property('bar', 'test bar 3');
+                    this.filtered[2].should.have.property('child');
+                });
+
+                it('does not clobber child objects', function() {
+                    this.filtered[0].child.should.deep.equal(this.data[0].child);
+                    this.filtered[1].child.should.deep.equal(this.data[1].child);
+                    this.filtered[2].child.should.deep.equal(this.data[2].child);
+                });
+
+                it('keeps internal properties that start with `$`', function() {
+                    this.filtered[0].should.have.property('$id', 'test id 1');
+                    this.filtered[0].child.should.have.property('$id', 'test child id 1');
+                    this.filtered[0].child.grandchild.should.have.property('$id', 'test grandchild id 1');
+                });
+
+                it('discards unspecified properties', function() {
+                    this.filtered[0].should.not.have.property('dur');
+                    this.filtered[1].should.not.have.property('dur');
+                    this.filtered[2].should.not.have.property('dur');
+                });
+            });
+
+            describe('nested props', function() {
+                beforeEach(function() {
+                    this.filtered = this.filter.props([
+                        '@foo',
+                        '@child.foo',
+                        '@child.bar',
+                        '@child.grandchild.bar',
+                        '@child.grandchild.dur'
+                    ]);
+                });
+
+                it('returns an array', function() {
+                    this.filtered.should.be.an('array');
+                });
+
+                it('keeps specified properties on all items', function() {
+                    this.filtered[0].should.have.property('foo', 'test foo 1');
+                    this.filtered[0].should.have.property('child');
+                    this.filtered[0].child.should.have.property('foo', 'test child foo 1');
+                    this.filtered[0].child.should.have.property('bar', 'test child bar 1');
+                    this.filtered[0].child.should.have.property('grandchild');
+                    this.filtered[0].child.grandchild.should.have.property('dur', 'test grandchild dur 1');
+
+                    this.filtered[1].should.have.property('foo', 'test foo 2');
+                    this.filtered[1].should.have.property('child');
+                    this.filtered[1].child.should.have.property('foo', 'test child foo 2');
+                    this.filtered[1].child.should.have.property('bar', 'test child bar 2');
+                    this.filtered[1].child.should.have.property('grandchild');
+                    this.filtered[1].child.grandchild.should.have.property('dur', 'test grandchild dur 2');
+
+                    this.filtered[2].should.have.property('foo', 'test foo 3');
+                    this.filtered[2].should.have.property('child');
+                    this.filtered[2].child.should.have.property('foo', 'test child foo 3');
+                    this.filtered[2].child.should.have.property('bar', 'test child bar 3');
+                    this.filtered[2].child.should.have.property('grandchild');
+                    this.filtered[2].child.grandchild.should.have.property('dur', 'test grandchild dur 3');
+                });
+
+                it('keeps nested internal properties that start with `$` on all items', function() {
+                    this.filtered[0].should.have.property('$id', 'test id 1');
+                    this.filtered[0].child.should.have.property('$id', 'test child id 1');
+                    this.filtered[0].child.grandchild.should.have.property('$id', 'test grandchild id 1');
+
+                    this.filtered[1].should.have.property('$id', 'test id 2');
+                    this.filtered[1].child.should.have.property('$id', 'test child id 2');
+                    this.filtered[1].child.grandchild.should.have.property('$id', 'test grandchild id 2');
+
+                    this.filtered[2].should.have.property('$id', 'test id 3');
+                    this.filtered[2].child.should.have.property('$id', 'test child id 3');
+                    this.filtered[2].child.grandchild.should.have.property('$id', 'test grandchild id 3');
+                });
+
+                it('discards unspecified properties on all items', function() {
+                    this.filtered[0].should.not.have.property('bar');
+                    this.filtered[0].should.not.have.property('dur');
+                    this.filtered[0].child.should.not.have.property('dur');
+                    this.filtered[0].child.grandchild.should.not.have.property('foo');
+
+                    this.filtered[1].should.not.have.property('bar');
+                    this.filtered[1].should.not.have.property('dur');
+                    this.filtered[1].child.should.not.have.property('dur');
+                    this.filtered[1].child.grandchild.should.not.have.property('foo');
+
+                    this.filtered[2].should.not.have.property('bar');
+                    this.filtered[2].should.not.have.property('dur');
+                    this.filtered[2].child.should.not.have.property('dur');
+                    this.filtered[2].child.grandchild.should.not.have.property('foo');
+                });
+            });
+        });
+    });
+
+    describe('object that contains array of objects', function() {
+        beforeEach(function() {
+            function createObject(id) {
+                return {
+                    $id: 'test id ' + id,
+                    foo: 'test foo ' + id,
+                    bar: 'test bar ' + id,
+                    dur: 'test dur ' + id,
+                };
+            };
+
+            this.data = {
+                items: [
+                    createObject(1),
+                    createObject(2),
+                    createObject(3)
+                ]
+            };
+
+            this.filter = new PropertyFilter(this.data);
+        });
+
+        describe('.props()', function() {
+            describe('top-level props from each item', function() {
+                beforeEach(function() {
+                    this.filtered = this.filter.props(['items@foo', 'items@bar']);
+                });
+
+                it('returns an object', function() {
+                    this.filtered.should.be.an('object');
+                });
+
+                it('keeps specified properties on all items', function() {
+                    this.filtered.items[0].should.have.property('foo', 'test foo 1');
+                    this.filtered.items[0].should.have.property('bar', 'test bar 1');
+
+                    this.filtered.items[1].should.have.property('foo', 'test foo 2');
+                    this.filtered.items[1].should.have.property('bar', 'test bar 2');
+
+                    this.filtered.items[2].should.have.property('foo', 'test foo 3');
+                    this.filtered.items[2].should.have.property('bar', 'test bar 3');
+                });
+
+                it('keeps nested internal properties that start with `$` on all items', function() {
+                    this.filtered.items[0].should.have.property('$id', 'test id 1');
+                    this.filtered.items[1].should.have.property('$id', 'test id 2');
+                    this.filtered.items[2].should.have.property('$id', 'test id 3');
+                });
+
+                it('discards unspecified properties on all items', function() {
+                    this.filtered.items[0].should.not.have.property('dur');
+                    this.filtered.items[1].should.not.have.property('dur');
+                    this.filtered.items[2].should.not.have.property('dur');
+                });
+            });
+        });
+    });
+
+    describe('array of objects that contains arrays of objects', function() {
+        beforeEach(function() {
+            function createObject(id) {
+                return {
+                    $id: 'test id ' + id,
+                    foo: 'test foo ' + id,
+                    bar: 'test bar ' + id,
+                    dur: 'test dur ' + id,
+                };
+            };
+
+            this.data = [
+                {
+                    items: [
+                        createObject(1),
+                        createObject(2),
+                        createObject(3)
+                    ]
+                },
+                {
+                    items: [
+                        createObject(4),
+                        createObject(5),
+                        createObject(6)
+                    ]
+                },
+                {
+                    items: [
+                        createObject(7),
+                        createObject(8),
+                        createObject(9)
+                    ]
+                }
+            ];
+
+            this.filter = new PropertyFilter(this.data);
+        });
+
+        describe('.props()', function() {
+            describe('top-level props from each item', function() {
+                beforeEach(function() {
+                    this.filtered = this.filter.props(['@items@foo', '@items@bar']);
+                });
+
+                it('returns an array', function() {
+                    this.filtered.should.be.an('array');
+                });
+
+                it('keeps specified properties on all items', function() {
+                    this.filtered[0].items[0].should.have.property('foo', 'test foo 1');
+                    this.filtered[0].items[0].should.have.property('bar', 'test bar 1');
+                    this.filtered[0].items[1].should.have.property('foo', 'test foo 2');
+                    this.filtered[0].items[1].should.have.property('bar', 'test bar 2');
+                    this.filtered[0].items[2].should.have.property('foo', 'test foo 3');
+                    this.filtered[0].items[2].should.have.property('bar', 'test bar 3');
+
+                    this.filtered[1].items[0].should.have.property('foo', 'test foo 4');
+                    this.filtered[1].items[0].should.have.property('bar', 'test bar 4');
+                    this.filtered[1].items[1].should.have.property('foo', 'test foo 5');
+                    this.filtered[1].items[1].should.have.property('bar', 'test bar 5');
+                    this.filtered[1].items[2].should.have.property('foo', 'test foo 6');
+                    this.filtered[1].items[2].should.have.property('bar', 'test bar 6');
+
+                    this.filtered[2].items[0].should.have.property('foo', 'test foo 7');
+                    this.filtered[2].items[0].should.have.property('bar', 'test bar 7');
+                    this.filtered[2].items[1].should.have.property('foo', 'test foo 8');
+                    this.filtered[2].items[1].should.have.property('bar', 'test bar 8');
+                    this.filtered[2].items[2].should.have.property('foo', 'test foo 9');
+                    this.filtered[2].items[2].should.have.property('bar', 'test bar 9');
+                });
+
+                it('keeps nested internal properties that start with `$` on all items', function() {
+                    this.filtered[0].items[0].should.have.property('$id', 'test id 1');
+                    this.filtered[0].items[1].should.have.property('$id', 'test id 2');
+                    this.filtered[0].items[2].should.have.property('$id', 'test id 3');
+
+                    this.filtered[1].items[0].should.have.property('$id', 'test id 4');
+                    this.filtered[1].items[1].should.have.property('$id', 'test id 5');
+                    this.filtered[1].items[2].should.have.property('$id', 'test id 6');
+
+                    this.filtered[2].items[0].should.have.property('$id', 'test id 7');
+                    this.filtered[2].items[1].should.have.property('$id', 'test id 8');
+                    this.filtered[2].items[2].should.have.property('$id', 'test id 9');
+                });
+
+                it('discards unspecified properties on all items', function() {
+                    this.filtered[0].items[0].should.not.have.property('dur');
+                    this.filtered[0].items[1].should.not.have.property('dur');
+                    this.filtered[0].items[2].should.not.have.property('dur');
+
+                    this.filtered[1].items[0].should.not.have.property('dur');
+                    this.filtered[1].items[1].should.not.have.property('dur');
+                    this.filtered[1].items[2].should.not.have.property('dur');
+
+                    this.filtered[2].items[0].should.not.have.property('dur');
+                    this.filtered[2].items[1].should.not.have.property('dur');
+                    this.filtered[2].items[2].should.not.have.property('dur');
+                });
+            });
+        });
+    });
+
+    describe('complex structure', function() {
+        beforeEach(function() {
+            function createObject(id) {
+                return {
+                    $id: 'test id ' + id,
+                    foo: 'test foo ' + id,
+                    bar: 'test bar ' + id,
+                    dur: 'test dur ' + id,
+                    children: [
+                        {
+                            lerp: 'test lerp 1 ' + id,
+                            merp: 'test merp 1 ' + id
+                        },
+                        {
+                            lerp: 'test lerp 2 ' + id,
+                            merp: 'test merp 2 ' + id
+                        },
+                        {
+                            lerp: 'test lerp 3 ' + id,
+                            merp: 'test merp 3 ' + id
+                        }
+                    ]
+                };
+            };
+
+            this.data = [
+                {
+                    items: [
+                        createObject(1),
+                        createObject(2),
+                        createObject(3)
+                    ]
+                },
+                {
+                    items: [
+                        createObject(4),
+                        createObject(5),
+                        createObject(6)
+                    ]
+                },
+                {
+                    items: [
+                        createObject(7),
+                        createObject(8),
+                        createObject(9)
+                    ]
+                }
+            ];
+
+            this.filter = new PropertyFilter(this.data);
+        });
+
+        describe('.props()', function() {
+            describe('top-level props from each item', function() {
+                beforeEach(function() {
+                    this.filtered = this.filter.props(['@items@foo', '@items@children@lerp']);
+                });
+
+                it('returns an array', function() {
+                    this.filtered.should.be.an('array');
+                });
+
+                it('keeps only what we asked for and special properties', function() {
+                    this.filtered.should.deep.equal([
+                        {
+                            items: [
+                                {
+                                    $id: 'test id 1',
+                                    foo: 'test foo 1',
+                                    children: [
+                                        { lerp: 'test lerp 1 1' },
+                                        { lerp: 'test lerp 2 1' },
+                                        { lerp: 'test lerp 3 1' }
+                                    ]
+                                },
+                                {
+                                    $id: 'test id 2',
+                                    foo: 'test foo 2',
+                                    children: [
+                                        { lerp: 'test lerp 1 2' },
+                                        { lerp: 'test lerp 2 2' },
+                                        { lerp: 'test lerp 3 2' }
+                                    ]
+                                },
+                                {
+                                    $id: 'test id 3',
+                                    foo: 'test foo 3',
+                                    children: [
+                                        { lerp: 'test lerp 1 3' },
+                                        { lerp: 'test lerp 2 3' },
+                                        { lerp: 'test lerp 3 3' }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            items: [
+                                {
+                                    $id: 'test id 4',
+                                    foo: 'test foo 4',
+                                    children: [
+                                        { lerp: 'test lerp 1 4' },
+                                        { lerp: 'test lerp 2 4' },
+                                        { lerp: 'test lerp 3 4' }
+                                    ]
+                                },
+                                {
+                                    $id: 'test id 5',
+                                    foo: 'test foo 5',
+                                    children: [
+                                        { lerp: 'test lerp 1 5' },
+                                        { lerp: 'test lerp 2 5' },
+                                        { lerp: 'test lerp 3 5' }
+                                    ]
+                                },
+                                {
+                                    $id: 'test id 6',
+                                    foo: 'test foo 6',
+                                    children: [
+                                        { lerp: 'test lerp 1 6' },
+                                        { lerp: 'test lerp 2 6' },
+                                        { lerp: 'test lerp 3 6' }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            items: [
+                                {
+                                    $id: 'test id 7',
+                                    foo: 'test foo 7',
+                                    children: [
+                                        { lerp: 'test lerp 1 7' },
+                                        { lerp: 'test lerp 2 7' },
+                                        { lerp: 'test lerp 3 7' }
+                                    ]
+                                },
+                                {
+                                    $id: 'test id 8',
+                                    foo: 'test foo 8',
+                                    children: [
+                                        { lerp: 'test lerp 1 8' },
+                                        { lerp: 'test lerp 2 8' },
+                                        { lerp: 'test lerp 3 8' }
+                                    ]
+                                },
+                                {
+                                    $id: 'test id 9',
+                                    foo: 'test foo 9',
+                                    children: [
+                                        { lerp: 'test lerp 1 9' },
+                                        { lerp: 'test lerp 2 9' },
+                                        { lerp: 'test lerp 3 9' }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]);
+                });
+            });
+        });
+    });
+});

--- a/test/lib/Symlink_test.js
+++ b/test/lib/Symlink_test.js
@@ -28,5 +28,5 @@ describe('Symlink', function() {
                 this.connection.get.calledWith(this.id).should.be.true;
             }.bind(this));
         });
-    })
+    });
 });


### PR DESCRIPTION
To fetch a nested property, simply use a `.` separator:

```
monocle.get('/users/123', {
  props: ['displayName', 'primaryPhoto.urlTemplate']
})
.then(function(user) {
  user.displayName; // 'Bob';
  user.primaryPhoto.urlTemplate; // 'http://...'
  user.primaryPhoto.photoId; // undefined
});
```

To specify which properties to pluck from an array of objects, use the `@` prefix:

```
monocle.get('/users', {
  props: ['@displayName', '@primaryPhoto.urlTemplate']
})
.then(function(users) {
  users[0].displayName; // 'Bob';
  users[0].primaryPhoto.urlTemplate; // 'http://...'
  users[0].primaryPhoto.photoId; // undefined
});
```

**Why the `@` prefix for arrays?**

This helps make it clear that you're expecting an array of items to be returned, and that the following property should be plucked. Also, the character is easy to type and can be used in a browser without too much trouble (unlike `#`).

**Example from the demo:**

```
$ curl http://localhost:5150/my-api/users?props=@userId,@displayName
[
  {
    "$id": "/users/1",
    "$expires": 3600,
    "userId": 1,
    "displayName": "Alice"
  },
  {
    "$id": "/users/2",
    "$expires": 3600,
    "userId": 2,
    "displayName": "Chris"
  },
  {
    "$id": "/users/3",
    "$expires": 3600,
    "userId": 3,
    "displayName": "Jane"
  },
  {
    "$id": "/users/4",
    "$expires": 3600,
    "userId": 4,
    "displayName": "Mark"
  },
  {
    "$id": "/users/5",
    "$expires": 3600,
    "userId": 5,
    "displayName": "Sarah"
  }
]
```
