### PR TITLE
Adds support for collection caching by implementing weak etags.

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -9,6 +9,7 @@ var _ = require('lodash');
 var Promise = require('bluebird');
 var Router = require('../lib');
 var Resource = require('../lib').Resource;
+var Collection = require('../lib').Collection;
 var Symlink = require('../lib').Symlink;
 
 /*** Set up simple HTTP server ***/
@@ -78,9 +79,10 @@ api.route('/users/:userId', userSchema, {
 // Defines the route that manages a collection of users
 api.route('/users', userCollectionSchema, {
     get: function(request, connection) {
-        return mockUserEmails.map(function(user) {
+        var users = mockUserEmails.map(function(user) {
             return new Symlink('/users/' + user.userId);
         });
+        return new Collection('/users', users, 1000);
     },
     post: createUser
 });

--- a/demo/schemas/user-collection.js
+++ b/demo/schemas/user-collection.js
@@ -5,6 +5,11 @@ module.exports = {
     $schema: 'http://json-schema.org/draft-04/schema#',
     title: 'User Collection',
     description: 'A collection of users.',
-    type: 'array',
-    items: userSchema // Each item in the collection is a user, so reuse the userSchema here
+    type: 'object',
+    properties: {
+        items: {
+            type: 'array',
+            items: userSchema // Each item in the collection is a user, so reuse the userSchema here
+        }
+    }
 };

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -1,0 +1,258 @@
+/**
+ * A Collection represents an array of items.
+ * The items may be Resources, Symlinks, primatives, or any combination.
+ * Collection objects provide a fluent interface to simplify their creation.
+ *
+ * ```js
+ * return new Collection('/users')
+ * .setItems([
+ *     new Symlink('/users/123'),
+ *     new Symlink('/users/789'),
+ *     new Symlink('/users/456')
+ * ])
+ * .setExpires(60000) // expires in 60 seconds
+ * .setTotal(500)     // total size of the collection
+ * .setLimit(10)      // limit specified by client
+ * .setOffset(0)      // offset specified by client
+ * ```
+ */
+var Collection = function(resourceId, items, expires) {
+    // Initial values default to `undefined`
+    // to prevent them from appearing in JSON until set
+    this.$type = 'collection';
+    this.$resourceId = undefined;
+    this.$expires = undefined;
+    this.total = undefined;
+    this.limit = undefined;
+    this.items = [];
+
+    if (typeof resourceId !== 'undefined') {
+        this.setResourceId(resourceId);
+    }
+
+    if (typeof items !== 'undefined') {
+        this.setItems(items);
+    }
+
+    if (typeof expires !== 'undefined') {
+        this.setExpires(expires);
+    }
+};
+
+/**
+ * Sets the resource ID for this collection.
+ *
+ * @param string|undefined - The new resource ID or `undefined` to remove it.
+ * @throws Error - Provided resource ID is invalid.
+ * @return this - Fluent interface.
+ */
+Collection.prototype.setResourceId = function(resourceId) {
+    var type = typeof resourceId;
+    if (type !== 'string' && type !== 'undefined') {
+        throw new Error("Expecting resourceId to be a string or undefined, but got " + typeof resourceId);
+    }
+    this.$resourceId = resourceId;
+    return this;
+};
+
+/**
+ * Gets the resource ID, or undefined if not set.
+ *
+ * @return string|undefined - The resource ID for this collection
+ */
+Collection.prototype.getResourceId = function() {
+    return this.$resourceId;
+};
+
+/**
+ * Sets the items in the collection.
+ *
+ * @param array items - Array of items that are in this collection.
+ *     May be an array of Resources, Symlinks, primatives, or any combination.
+ * @throws Error - When non-array is passed in.
+ * @return this - Fluent interface.
+ */
+Collection.prototype.setItems = function(items) {
+    if (!Array.isArray(items)) {
+        throw new Error("Expecting items to be an array, got " + typeof items);
+    }
+    this.items = items;
+    return this;
+};
+
+/**
+ * Gets the items in the collection.
+ *
+ * @return array - All items in the collection.
+ */
+Collection.prototype.getItems = function() {
+    return this.items;
+};
+
+/**
+ * Sets the value for an item in the collection.
+ *
+ * @param integer position - The array position.
+ * @param array item - Item to be placed into specified position.
+ * @throws Error - Invalid position.
+ * @return this - Fluent interface.
+ */
+Collection.prototype.setItem = function(position, item) {
+    if (typeof position !== 'number') {
+        throw new Error("Expecting position to be a number, got " + typeof position);
+    }
+
+    if (position < 0) {
+        throw new Error("Expecting position to be 0 or greater");
+    }
+
+    this.items[position] = item;
+    return this;
+};
+
+/**
+ * Returns the value for an item in the collection, or undefined if not set.
+ *
+ * @param integer position - The array position.
+ * @return mixed - The item at the position in the collection or undefined.
+ */
+Collection.prototype.getItem = function(position) {
+    return this.items[position];
+};
+
+/**
+ * Sets the expiration for the collection in milliseconds.
+ *
+ * @param integer|undefined - Maximum number of milliseconds this collection may be cached for.
+ * @throws Error - Expiration is invalid.
+ * @return this - Fluent interface.
+ */
+Collection.prototype.setExpires = function(expires) {
+    var type = typeof expires;
+
+    if (expires < 0) {
+        throw new Error("Expecting expires to be 0 or greater");
+    }
+
+    if (type !== 'number' && type !== undefined) {
+        throw new Error("Expecting expires to be a number or undefined, got " + typeof expires);
+    }
+
+    this.$expires = expires;
+    return this;
+};
+
+/**
+ * Returns the expiration for the collection in milliseconds, or undefined if not set.
+ *
+ * @return integer|undefined - Maximum number of milliseconds this collection may be cached for.
+ */
+Collection.prototype.getExpires = function() {
+    return this.$expires;
+};
+
+/**
+ * Sets the total number of items in the collection.
+ * May be more than the number of items represented.
+ *
+ * @param integer total - Number of items in the collection.
+ * @throws Error - Total is invalid.
+ * @return mixed - Total number of items in collection if no argument provided,
+ *     otherwise returns `this` for fluent interface
+ */
+Collection.prototype.setTotal = function(total) {
+    var type = typeof total;
+
+    if (total < 0) {
+        throw new Error("Expecting total to be 0 or greater");
+    }
+
+    if (type !== 'number' && type !== undefined) {
+        throw new Error("Expecting total to be a number or undefined, got " + typeof total);
+    }
+
+    this.total = total;
+    return this;
+};
+
+/**
+ * Returns the total number of items in the collection, or undefined if not set.
+ *
+ * @return integer|undefined - Total number of items in the collection
+ */
+Collection.prototype.getTotal = function() {
+    return this.total;
+};
+
+/**
+ * Sets the limit of items in the collection, or undefined if no limit is set.
+ *
+ * @param integer|undefined limit - Limit of items in the collection.
+ * @throws Error - Limit is invalid.
+ * @return this - Fluent interface.
+ */
+Collection.prototype.setLimit = function(limit) {
+    var type = typeof limit;
+
+    if (limit < 0) {
+        throw new Error("Expecting limit to be 0 or greater");
+    }
+
+    if (type !== 'number' && type !== undefined) {
+        throw new Error("Expecting limit to be a number or undefined, got " + typeof limit);
+    }
+
+    this.limit = limit;
+    return this;
+};
+
+/**
+ * Returns the limit of items in the collection, or undefined if not set.
+ *
+ * @return integer|undefined - Limit of items in the collection.
+ */
+Collection.prototype.getLimit = function() {
+    return this.limit;
+};
+
+/**
+ * Removes the last item from the collection and returns it.
+ *
+ * @return mixed
+ */
+Collection.prototype.pop = function() {
+    return this.items.pop();
+};
+
+/**
+ * Adds the item to the end of the collection.
+ *
+ * @param mixed item - The item to add
+ * @return this - fluent interface
+ */
+Collection.prototype.push = function(item) {
+    this.items.push(item);
+    return this;
+};
+
+/**
+ * Removes the first item from the collection and returns it.
+ *
+ * @return mixed
+ */
+Collection.prototype.shift = function() {
+    return this.items.shift();
+};
+
+/**
+ * Adds the item to the beginning of the collection.
+ *
+ * @param mixed item - The item to add
+ * @return this - fluent interface
+ */
+Collection.prototype.unshift = function(item) {
+    this.items.unshift(item);
+    return this;
+};
+
+module.exports = Collection;

--- a/lib/CollectionCache.js
+++ b/lib/CollectionCache.js
@@ -1,0 +1,97 @@
+var crypto = require('crypto');
+
+/**
+ * Given a collection and request details,
+ * determines a "weak" etag.
+ */
+var CollectionCache = function(collection, request) {
+    this.collection = collection;
+    this.request = request;
+};
+
+/**
+ * Generates a "weak" etag for the collection.
+ * Returns `false` if a weak etag cannot be created.
+ *
+ * @returns string|false - Weak etag
+ */
+CollectionCache.prototype.id = function() {
+    if (this.collection.$type !== 'collection' || !this.collection.$resourceId || !this.collection.$expires) {
+        return false;
+    }
+
+    var hasMissingIdentity = false;
+    var items = this.collection.items;
+
+    // 1. Gather resource IDs in collection
+    var resourceIds = items.map(function(item) {
+        if (item.$link) {
+            return item.$link;
+        }
+
+        if (item.$id) {
+            return item.$id;
+        }
+
+        // Item has no identity
+        hasMissingIdentity = true;
+    });
+
+    if (hasMissingIdentity) {
+        // Cannot create an etag if identities are missing
+        return false;
+    }
+
+    // 2. Gather requested props, alphabetized
+    var props = [].concat(this.request.getProps()).sort();
+
+    // 3. Gather all other query string parameters
+    var query = this.request.getUrl().search
+    .replace(/^\?/, '')             // remove "?" from beginning of string
+    .split('&')                     // create array of keyvalue parts
+    .filter(function(keyvalue) {    // filter out "props" query string param
+        return !keyvalue.match(/^props=/)
+    })
+    .sort();                        // sort alphabetically
+
+    // 4. Generate a string of metadata
+    var metadataString = JSON.stringify([
+        resourceIds,
+        props,
+        query
+    ]);
+
+    // 5. Generate a sha256 hash of the metadata
+    var sha256Hash = crypto
+    .createHash('sha256')
+    .update(metadataString, 'utf8')
+    .digest('hex');
+
+    // 6. Make a weak etag
+    return 'W/"' + sha256Hash + '"';
+};
+
+/**
+ * Verifies an etag. Returns `true` if it matches.
+ *
+ * @param string etag - The etag to check.
+ * @return boolean - True if passes validation.
+ */
+CollectionCache.prototype.isValid = function(etag) {
+    if (!etag) {
+        return false;
+    }
+
+    if (!etag.match(/W\/"[0-9a-f]+"/)) {
+        return false;
+    }
+
+    var actualEtag = this.id();
+    if (!actualEtag) {
+        return false;
+    }
+
+    return etag === actualEtag;
+};
+
+module.exports = CollectionCache;

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -35,6 +35,8 @@ Request.prototype.setUrl = function(url) {
     this._props = (this._url.query.props || '').split(',').filter(function(value) {
         return value;
     });
+
+    this._etag = null;
 };
 
 Request.prototype.getUrl = function() {
@@ -129,6 +131,15 @@ Request.prototype.setResource = function(resource) {
 
 Request.prototype.getResource = function() {
     return this._resource;
+};
+
+Request.prototype.setEtag = function(etag) {
+    this._etag = etag;
+    return this;
+};
+
+Request.prototype.getEtag = function() {
+    return this._etag;
 };
 
 Request.prototype.error = function(httpStatusCode, message) {

--- a/lib/Router.js
+++ b/lib/Router.js
@@ -13,6 +13,8 @@ var HttpStatusCodes = require('./HttpStatusCodes');
 var errorSchema = require('./schemas/error');
 var validationErrors = require('./models/validationErrors');
 var Resource = require('./Resource');
+var Collection = require('./Collection');
+var CollectionCache = require('./CollectionCache');
 
 module.exports = Router;
 
@@ -325,10 +327,32 @@ Router.prototype.handle = function(request, connection) {
         // Restrict by props before resolving symlinks to delete symlinks that are not needed.
         result = restrictProps(result, props);
 
+        // Validate etag for GET requests of arrays
+        if (method === Request.METHOD_GET) {
+            var etag = request.getEtag();
+            var collectionCache = new CollectionCache(result, request);
+
+            // Validate etag
+            if (etag && collectionCache.isValid(etag)) {
+                // Emit success event
+                emit.call(this, 'api:success', request, route, timeStart);
+                return {
+                    $httpStatus: 304
+                };
+            }
+        }
+
         // Resolve symlinks
         return resolveSymlinks(result, connection, props).then(function() {
             // Now that all symlinks are resolved, restrict again
             result = restrictProps(result, props);
+
+            // Add etags to all GETs for collections
+            if (method === Request.METHOD_GET) {
+                var collectionCache = new CollectionCache(result, request);
+                var etag = collectionCache.id();
+                if (etag) result.$etag = etag;
+            }
 
             // Validate responses except for DELETE methods
             if (!result.$httpStatus && method !== Request.METHOD_DELETE) {
@@ -458,6 +482,14 @@ var respondJson = function(res, obj) {
         res.statusCode = obj.$httpStatus;
     }
 
+    if (obj.$etag) {
+        res.setHeader('etag', obj.$etag);
+    }
+
+    if (obj.$expires) {
+        res.setHeader('cache-control', 'private, max-age=' + obj.$expires);
+    }
+
     try {
         var body = JSON.stringify(obj, null, 2) + '\n';
     } catch (e) {
@@ -525,6 +557,11 @@ Router.prototype.middleware = function(options) {
 
         var connection = new Connection(this, req, res);
         var request = new Request(req.url, this, connection);
+
+        if (req.headers['if-none-match']) {
+            request.setEtag(req.headers['if-none-match']);
+        };
+
         var parsedUrl = request.getUrl();
         request.setMethod(req.method);
 
@@ -551,20 +588,31 @@ Router.prototype.batch = function(req, res) {
         request.setMethod(envelope.method);
         request.setResourceId(parsedUrl.pathname);
 
-        if (envelope.body) {
-            request.setResource(envelope.body);
+        if (envelope.headers) {
+            if (envelope.headers['if-none-match']) {
+                request.setEtag(envelope.headers['if-none-match']);
+            }
         }
+
+        if (envelope.body) request.setResource(envelope.body);
 
         return this.handle(request, connection)
         .then(function(result) {
+            var headers = {};
+
+            if (result.$etag) headers.etag = result.$etag;
+            if (result.$expires) headers['cache-control'] = 'private, max-age=' + result.$expires;
+
             return {
-                status: 200,
+                status: result.$httpStatus || 200,
+                headers: headers,
                 body: result
             };
         })
         .catch(function(error) {
             return {
-                status: 404,
+                headers: {},
+                status: error.$httpStatus || 500,
                 body: error
             };
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 module.exports = require('./Router');
 module.exports.Request = require('./Request');
 module.exports.Resource = require('./Resource');
+module.exports.Collection = require('./Collection');
 module.exports.Connection = require('./Connection');
 module.exports.Symlink = require('./Symlink');

--- a/test/lib/CollectionCache_test.js
+++ b/test/lib/CollectionCache_test.js
@@ -1,0 +1,171 @@
+var CollectionCache = require('../../lib/CollectionCache');
+var Collection = require('../../lib/Collection');
+var Request = require('../../lib/Request');
+var Resource = require('../../lib/Resource');
+var Symlink = require('../../lib/Symlink');
+
+describe('CollectionCache', function() {
+    it('is a function', function() {
+        CollectionCache.should.be.a('function');
+    });
+
+    function suiteWeakEtagTests() {
+        describe('id()', function() {
+            it('returns a weak etag', function() {
+                var etag = this.collectionCache.id();
+                etag.should.match(/W\/"[0-9a-f]+"/);
+            });
+
+            it('generates the same etag on multiple calls', function() {
+                var etag1 = this.collectionCache.id();
+                var etag2 = this.collectionCache.id();
+                etag1.should.equal(etag2);
+            });
+
+            it('generates a new etag if the order of items changes', function() {
+                var etag1 = this.collectionCache.id();
+                this.collection.push(this.collection.shift());
+                var etag2 = this.collectionCache.id();
+                etag1.should.not.equal(etag2);
+            });
+
+            it('generates a new etag if a new item is added to the collection', function() {
+                var etag1 = this.collectionCache.id();
+                this.collection.push({ $id: '/users/4' });
+                var etag2 = this.collectionCache.id();
+                etag1.should.not.equal(etag2);
+            });
+
+            it('generates a new etag if an item is removed from the collection', function() {
+                var etag1 = this.collectionCache.id();
+                this.collection.pop();
+                var etag2 = this.collectionCache.id();
+                etag1.should.not.equal(etag2);
+            });
+
+            it('generates the same etag if the props are specified in a different order', function() {
+                var etag1 = this.collectionCache.id();
+                var request2 = new Request('/users?props=@age,@name&offset=0&limit=10');
+                var collectionCache2 = new CollectionCache(this.collection, request2);
+                var etag2 = this.collectionCache.id();
+                etag1.should.equal(etag2);
+            });
+
+            it('generates a new etag if different props are requested', function() {
+                var etag1 = this.collectionCache.id();
+                var request2 = new Request('/users?props=@photo,@location&offset=0&limit=10');
+                var collectionCache2 = new CollectionCache(this.collection, request2);
+                var etag2 = this.collectionCache.id();
+                etag1.should.equal(etag2);
+            });
+
+            it('generates the same etag if the the query string parameters are specified in a different order', function() {
+                var etag1 = this.collectionCache.id();
+                var request2 = new Request('/users?props=@name,@age&limit=10&offset=0');
+                var collectionCache2 = new CollectionCache(this.collection, request2);
+                var etag2 = this.collectionCache.id();
+                etag1.should.equal(etag2);
+            });
+
+            it('generates a new etag if different query string parameters are requested', function() {
+                var etag1 = this.collectionCache.id();
+                var request2 = new Request('/users?props=@name,@age&offset=10&limit=10');
+                var collectionCache2 = new CollectionCache(this.collection, request2);
+                var etag2 = this.collectionCache.id();
+                etag1.should.equal(etag2);
+            });
+
+            it('generates the same weak etag if the data of an item changes', function() {
+                var etag1 = this.collectionCache.id();
+                this.collection.getItem(0).anything = 'test anything';
+                var etag2 = this.collectionCache.id();
+                etag1.should.equal(etag2);
+            });
+        });
+    }
+
+    function suiteIsValidTests() {
+        describe('isValid()', function() {
+            it('is true for matching etag', function() {
+                var etag = this.collectionCache.id();
+                this.collectionCache.isValid(etag).should.be.true;
+            });
+
+            it('is false for none-matching etag', function() {
+                var etag = 'W/"anything"';
+                this.collectionCache.isValid(etag).should.be.false;
+            });
+
+            it('is false for falsy values', function() {
+                var etag = false;
+                this.collectionCache.isValid(etag).should.be.false;
+            });
+
+            it('is false for non-weak etag', function() {
+                var etag = '"anything"';
+                this.collectionCache.isValid(etag).should.be.false;
+            });
+        });
+    }
+
+    describe('with collection of resources', function() {
+        beforeEach(function() {
+            this.collection = new Collection('/users', [
+                // items are intentionally not in order
+                new Resource('/users/2', {}, 60000),
+                new Resource('/users/3', {}, 60000),
+                new Resource('/users/1', {}, 60000)
+            ], 1000);
+
+            this.request = new Request('/users?props=@name,@age&offset=0&limit=10');
+            this.collectionCache = new CollectionCache(this.collection, this.request);
+        });
+
+        suiteWeakEtagTests();
+        suiteIsValidTests();
+    });
+
+    describe('with collection of symlinks', function() {
+        beforeEach(function() {
+            this.collection = new Collection('/users', [
+                // items are intentionally not in order
+                new Symlink('/users/2'),
+                new Symlink('/users/3'),
+                new Symlink('/users/1')
+            ], 1000);
+
+            this.request = new Request('/users?props=@name,@age&offset=0&limit=10');
+            this.collectionCache = new CollectionCache(this.collection, this.request);
+        });
+
+        suiteWeakEtagTests();
+        suiteIsValidTests();
+    });
+
+    describe('with collection of objects that have no identity', function() {
+        beforeEach(function() {
+            this.collection = new Collection('/users', [
+                // items are intentionally not in order
+                {foo: 'test foo 2'},
+                {foo: 'test foo 3'},
+                {foo: 'test foo 1'}
+            ], 1000);
+
+            this.request = new Request('/users?props=@name,@age&offset=0&limit=10');
+            this.collectionCache = new CollectionCache(this.collection, this.request);
+        });
+
+        describe('id()', function() {
+            it('returns false', function() {
+                this.collectionCache.id().should.be.false;
+            });
+        });
+
+        describe('isValid()', function() {
+            it('returns false', function() {
+                var etag = 'W/"anything"';
+                this.collectionCache.isValid(etag).should.be.false;
+            });
+        });
+    });
+});

--- a/test/lib/Collection_test.js
+++ b/test/lib/Collection_test.js
@@ -1,0 +1,283 @@
+var Collection = require('../../lib/Collection');
+
+describe('Collection', function() {
+    beforeEach(function() {
+        this.resourceId = '/my-resources';
+        this.items = [0, 1, 2];
+        this.expires = 1000;
+        this.collection = new Collection(this.resourceId, this.items, this.expires);
+    });
+
+    describe('resource id', function() {
+        it('can be retrieved', function() {
+            this.collection.getResourceId().should.equal(this.resourceId);
+        });
+
+        [
+            '/anything',
+            undefined
+        ].forEach(function(validResourceId) {
+            it('can be set to ' + JSON.stringify(validResourceId), function() {
+                this.collection.setResourceId(validResourceId);
+                expect(this.collection.getResourceId()).to.equal(validResourceId);
+            });
+        });
+
+        [
+            {},
+            [],
+            123,
+            1.23,
+            function() {},
+            null,
+            true,
+            false
+        ].forEach(function(invalidResourceId) {
+            it('throws an error if set to ' + JSON.stringify(invalidResourceId), function() {
+                expect(function() {
+                    this.collection.setResourceId(invalidResourceId);
+                }.bind(this)).to.throw();
+            });
+        });
+    });
+
+    describe('items', function() {
+        it('can be retrieved', function() {
+            this.collection.getItems().should.deep.equal(this.items);
+        });
+
+        it('can be replaced', function() {
+            var updatedItems = [7, 8, 9];
+            this.collection.setItems(updatedItems);
+            this.collection.getItems().should.deep.equal(updatedItems);
+        });
+
+        [
+            {},
+            123,
+            1.23,
+            function() {},
+            null,
+            true,
+            false
+        ].forEach(function(invalidItems) {
+            it('throws an error if set to ' + JSON.stringify(invalidItems), function() {
+                expect(function() {
+                    this.collection.setItems(invalidItems);
+                }.bind(this)).to.throw();
+            });
+        });
+    });
+
+    describe('individual item', function() {
+        it('can be retrieved', function() {
+            this.collection.getItem(0).should.equal(0);
+            this.collection.getItem(1).should.equal(1);
+            this.collection.getItem(2).should.equal(2);
+        });
+
+        it('can be replaced', function() {
+            this.collection.setItem(0, 'foo');
+            this.collection.getItem(0).should.equal('foo');
+        });
+
+        [
+            {},
+            [],
+            -1,
+            function() {},
+            null,
+            true,
+            false
+        ].forEach(function(invalidPosition) {
+            it('throws an error if position set ' + JSON.stringify(invalidPosition), function() {
+                expect(function() {
+                    this.collection.setItem(invalidPosition, 'anything');
+                }.bind(this)).to.throw();
+            });
+        });
+    });
+
+    describe('expiration', function() {
+        it('can be retrieved', function() {
+            this.collection.getExpires().should.equal(this.expires);
+        });
+
+        it('can be set', function() {
+            this.collection.setExpires(5000);
+            this.collection.getExpires().should.equal(5000);
+        });
+
+        [
+            {},
+            [],
+            -1,
+            function() {},
+            null,
+            true,
+            false
+        ].forEach(function(invalidExpires) {
+            it('throws an error if set to ' + JSON.stringify(invalidExpires), function() {
+                expect(function() {
+                    this.collection.setExpires(invalidExpires);
+                }.bind(this)).to.throw();
+            });
+        });
+    });
+
+    describe('total', function() {
+        it('can be retreived', function() {
+            expect(this.collection.getTotal()).to.be.undefined;
+        });
+
+        it('can be overwritten', function() {
+            this.collection.setTotal(100);
+            this.collection.getTotal().should.equal(100);
+        });
+
+        [
+            {},
+            [],
+            -1,
+            function() {},
+            null,
+            true,
+            false
+        ].forEach(function(invalidTotal) {
+            it('throws an error if set to ' + JSON.stringify(invalidTotal), function() {
+                expect(function() {
+                    this.collection.setTotal(invalidTotal);
+                }.bind(this)).to.throw();
+            });
+        });
+    });
+
+    describe('limit', function() {
+        it('can be retreived', function() {
+            expect(this.collection.getLimit()).to.be.undefined;
+        });
+
+        it('can be overwritten', function() {
+            this.collection.setLimit(10);
+            this.collection.getLimit().should.equal(10);
+        });
+
+        [
+            {},
+            [],
+            -1,
+            function() {},
+            null,
+            true,
+            false
+        ].forEach(function(invalidLimit) {
+            it('throws an error if set to ' + JSON.stringify(invalidLimit), function() {
+                expect(function() {
+                    this.collection.setLimit(invalidLimit);
+                }.bind(this)).to.throw();
+            });
+        });
+    });
+
+    describe('.pop()', function() {
+        it('returns the last item', function() {
+            this.collection.pop().should.equal(2);
+        });
+
+        it('removes the last item', function() {
+            this.collection.pop();
+            this.collection.getItems().should.deep.equal([0, 1]);
+        });
+    });
+
+    describe('.push()', function() {
+        it('adds the item to the end of the collection', function() {
+            this.collection.push('foo');
+            this.collection.getItems().should.deep.equal([0, 1, 2, 'foo']);
+        });
+
+        it('returns this', function() {
+            this.collection.push('anything').should.equal(this.collection);
+        });
+    });
+
+    describe('.shift()', function() {
+        it('returns the last item', function() {
+            this.collection.shift().should.equal(0);
+        });
+
+        it('removes the first item', function() {
+            this.collection.shift();
+            this.collection.getItems().should.deep.equal([1, 2]);
+        });
+    });
+
+    describe('.unshift()', function() {
+        it('adds the item to the beginning of the collection', function() {
+            this.collection.unshift('foo');
+            this.collection.getItems().should.deep.equal(['foo', 0, 1, 2]);
+        });
+
+        it('returns this', function() {
+            this.collection.unshift('anything').should.equal(this.collection);
+        });
+    });
+
+    describe('stringification', function() {
+        beforeEach(function() {
+            this.collection = new Collection();
+            this.objectify = function() {
+                this.stringified = JSON.stringify(this.collection);
+                return JSON.parse(this.stringified);
+            }.bind(this);
+        });
+
+        it('does not contain $resourceId property if not set', function() {
+            this.objectify().should.not.have.property('$resourceId');
+        });
+
+        it('contains $resourceId property if set', function() {
+            this.collection.setResourceId('/foos')
+            this.objectify().should.have.property('$resourceId', '/foos');
+        });
+
+        it('does not contain $expires property if not set', function() {
+            this.objectify().should.not.have.property('$expires');
+        });
+
+        it('contains $expires property', function() {
+            this.collection.setExpires(1000);
+            this.objectify().should.have.property('$expires', 1000);
+        });
+
+        it('does not contain $total property if not specified', function() {
+            this.objectify().should.not.have.property('total');
+        });
+
+        it('contains $total property if set', function() {
+            this.collection.setTotal(100);
+            this.objectify().should.have.property('total', 100);
+        });
+
+        it('does not contain $limit property if not specified', function() {
+            this.objectify().should.not.have.property('limit');
+        });
+
+        it('contains $limit property if set', function() {
+            this.collection.setLimit(10);
+            this.objectify().should.have.property('limit', 10);
+        });
+
+        it('contains items property', function() {
+            var objectified = this.objectify();
+            objectified.should.have.property('items');
+            objectified.items.should.be.an('array');
+        });
+
+        it('contains items specified in collection', function() {
+            var items = [0, 1, 2];
+            this.collection.setItems(items);
+            this.objectify().items.should.deep.equal(items);
+        });
+    });
+});

--- a/test/lib/index_test.js
+++ b/test/lib/index_test.js
@@ -9,6 +9,10 @@ describe('Module', function() {
         Router.Resource.should.be.a('function');
     });
 
+    it('exposes .Collection', function() {
+        Router.Collection.should.be.a('function');
+    });
+
     it('exposes .Request', function() {
         Router.Request.should.be.a('function');
     });


### PR DESCRIPTION
Collection caching strategy detailed here: https://docs.google.com/a/tagged.com/document/d/1bQ_cpx7DSf5LoxG96WMtXn3fgkNnonb4WArTOH86qIE/edit?usp=sharing

**Example usage**

First, we make an initial `GET` request for a collection at `/users`. The local cache is empty, so we do not send `if-none-match` header.

```
$ curl -v http://127.0.0.1:5150/my-api/users?props=items@displayName,items@age,items@gender
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 5150 (#0)
> GET /my-api/users?props=items@displayName,items@age,items@gender HTTP/1.1
> Host: 127.0.0.1:5150
> User-Agent: curl/7.43.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Content-Type: application/json
< etag: W/"212a0595913e7b1ddf15efeefd3846c2939f4c53772e0cf7d80dfabd8254a5e3"
< cache-control: private, max-age=1000
< Date: Tue, 12 Jan 2016 23:33:36 GMT
< Connection: keep-alive
< Transfer-Encoding: chunked
< 
{
  "$type": "collection",
  "$resourceId": "/users",
  "$expires": 1000,
  "items": [
    {
      "$id": "/users/1",
      "$expires": 3600,
      "displayName": "Alice",
      "age": 27,
      "gender": "F"
    },
    {
      "$id": "/users/2",
      "$expires": 3600,
      "displayName": "Chris",
      "age": 22,
      "gender": "M"
    },
    {
      "$id": "/users/3",
      "$expires": 3600,
      "displayName": "Jane",
      "age": 31,
      "gender": "F"
    },
    {
      "$id": "/users/4",
      "$expires": 3600,
      "displayName": "Mark",
      "age": 37,
      "gender": "M"
    },
    {
      "$id": "/users/5",
      "$expires": 3600,
      "displayName": "Sarah",
      "age": 47,
      "gender": "F"
    }
  ],
  "$etag": "W/\"212a0595913e7b1ddf15efeefd3846c2939f4c53772e0cf7d80dfabd8254a5e3\""
}
```

Monocle responded with the collection and told us we can cache the collection for up to 1000ms. Additionally, a weak ETag was returned, which we can use later to validate our cached copy. So if we make another `GET` request before the 1000ms expires, we may pass along the weak ETag in an `if-none-match` header to validate with the server:

```
$ curl -v -H 'if-none-match: W/"212a0595913e7b1ddf15efeefd3846c2939f4c53772e0cf7d80dfabd8254a5e3"' http://127.0.0.1:5150/my-api/users?props=items@displayName,items@age,items@gender
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 5150 (#0)
> GET /my-api/users?props=items@displayName,items@age,items@gender HTTP/1.1
> Host: 127.0.0.1:5150
> User-Agent: curl/7.43.0
> Accept: */*
> if-none-match: W/"212a0595913e7b1ddf15efeefd3846c2939f4c53772e0cf7d80dfabd8254a5e3"
> 
< HTTP/1.1 304 Not Modified
< Content-Type: application/json
< Date: Tue, 12 Jan 2016 23:33:55 GMT
< Connection: keep-alive
< 
```

The Monocle server was able to verify that the items in the collection are still in the same order as the cached version, so it responded with `304 Not Modified`. This informs our client that we may use our local cache instead of recreating the objects from the response.

Note that the order of the requested properties does not matter, so long as the same properties are requested:

```
$ curl -v -H 'if-none-match: W/"212a0595913e7b1ddf15efeefd3846c2939f4c53772e0cf7d80dfabd8254a5e3"' http://127.0.0.1:5150/my-api/users?props=items@displayName,items@gender,items@age
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 5150 (#0)
> GET /my-api/users?props=items@displayName,items@gender,items@age HTTP/1.1
> Host: 127.0.0.1:5150
> User-Agent: curl/7.43.0
> Accept: */*
> if-none-match: W/"212a0595913e7b1ddf15efeefd3846c2939f4c53772e0cf7d80dfabd8254a5e3"
> 
< HTTP/1.1 304 Not Modified
< Content-Type: application/json
< Date: Tue, 12 Jan 2016 23:34:07 GMT
< Connection: keep-alive
< 
```

If the weak ETag we pass in no longer matches what the server generates, then we get a `200 OK` response with the new data. There are many scenarios that would result in a new ETag being generated on the server:
- The order of the items in the collection have changed
- The collection represents a different set of items
- The requested parameters have changed
- Other query string parameters have changed (e.g. `?offset=0` vs `?offset=10`)

In this example, the order of the users has changed, so our weak ETag no longer validates:

```
$ curl -v -H 'if-none-match: W/"212a0595913e7b1ddf15efeefd3846c2939f4c53772e0cf7d80dfabd8254a5e3"' http://127.0.0.1:5150/my-api/users?props=items@displayName,items@gender,items@age
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 5150 (#0)
> GET /my-api/users?props=items@displayName,items@gender,items@age HTTP/1.1
> Host: 127.0.0.1:5150
> User-Agent: curl/7.43.0
> Accept: */*
> if-none-match: W/"212a0595913e7b1ddf15efeefd3846c2939f4c53772e0cf7d80dfabd8254a5e3"
> 
< HTTP/1.1 200 OK
< Content-Type: application/json
< etag: W/"94add1e2cc693ae79c834255b12b4db6e0569679c1d70e805b1928c16c87eeb5"
< cache-control: private, max-age=5000
< Date: Tue, 12 Jan 2016 23:34:32 GMT
< Connection: keep-alive
< Transfer-Encoding: chunked
< 
{
  "$type": "collection",
  "$resourceId": "/users",
  "$expires": 5000,
  "items": [
    {
      "$id": "/users/2",
      "$expires": 3600,
      "displayName": "Chris",
      "gender": "M",
      "age": 22
    },
    {
      "$id": "/users/1",
      "$expires": 3600,
      "displayName": "Alice",
      "gender": "F",
      "age": 27
    },
    {
      "$id": "/users/4",
      "$expires": 3600,
      "displayName": "Mark",
      "gender": "M",
      "age": 37
    },
    {
      "$id": "/users/5",
      "$expires": 3600,
      "displayName": "Sarah",
      "gender": "F",
      "age": 47
    },
    {
      "$id": "/users/3",
      "$expires": 3600,
      "displayName": "Jane",
      "gender": "F",
      "age": 31
    }
  ],
  "$etag": "W/\"94add1e2cc693ae79c834255b12b4db6e0569679c1d70e805b1928c16c87eeb5\""
}
```

Note that the following scenarios will **not** result in a new ETag being generated on the server:
- A value of one of the items in the array has changed. For example, if `/users/1` changes her `displayName` to from "Alice" to "Supergirl", this will have no effect on the weak ETag.

Batched calls are also supported. Here's the result of a batched call to get the `/users` collection:

```
$ curl -v -X POST -H 'Content-Type: application/json' -d '[{ "method": "GET", "url": "/users?props=items@displayName,items@age" }]' http://127.0.0.1:5150/my-api/_batch
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 5150 (#0)
> POST /my-api/_batch HTTP/1.1
> Host: 127.0.0.1:5150
> User-Agent: curl/7.43.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 72
> 
* upload completely sent off: 72 out of 72 bytes
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Wed, 13 Jan 2016 01:34:33 GMT
< Connection: keep-alive
< Transfer-Encoding: chunked
< 
[
  {
    "status": 200,
    "headers": {
      "etag": "W/\"5542b39ae78a568636ee13ecdf93609c6a861cec8c4fef9fe6169d32809157af\"",
      "cache-control": "private, max-age=1000"
    },
    "body": {
      "$type": "collection",
      "$resourceId": "/users",
      "$expires": 1000,
      "items": [
        {
          "$id": "/users/1",
          "$expires": 3600,
          "displayName": "Alice",
          "age": 27
        },
        {
          "$id": "/users/2",
          "$expires": 3600,
          "displayName": "Chris",
          "age": 22
        },
        {
          "$id": "/users/3",
          "$expires": 3600,
          "displayName": "Jane",
          "age": 31
        },
        {
          "$id": "/users/4",
          "$expires": 3600,
          "displayName": "Mark",
          "age": 37
        },
        {
          "$id": "/users/5",
          "$expires": 3600,
          "displayName": "Sarah",
          "age": 47
        }
      ],
      "$etag": "W/\"5542b39ae78a568636ee13ecdf93609c6a861cec8c4fef9fe6169d32809157af\""
    }
  }
]
```

Here's the result when passing in a valid `if-none-matches` header to the batch endpoint:

```
$ curl -v -X POST -H 'Content-Type: application/json' -d '[{ "method": "GET", "url": "/users?props=items@displayName,items@age", "headers": {"if-none-match": "W/\"5542b39ae78a568636ee13ecdf93609c6a861cec8c4fef9fe6169d32809157af\"" } }]' http://127.0.0.1:5150/my-api/_batch
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 5150 (#0)
> POST /my-api/_batch HTTP/1.1
> Host: 127.0.0.1:5150
> User-Agent: curl/7.43.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 177
> 
* upload completely sent off: 177 out of 177 bytes
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Wed, 13 Jan 2016 01:34:43 GMT
< Connection: keep-alive
< Transfer-Encoding: chunked
< 
[
  {
    "status": 304,
    "headers": {},
    "body": {
      "$httpStatus": 304
    }
  }
]
```
