### PR TITLE
Allows resources to be uncacheable by omitting the `$expires` property

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -4,6 +4,6 @@ module.exports = Resource;
 
 function Resource(id, data, expires) {
     this.$id = id;
-    this.$expires = parseInt(expires, 10) || 0;
+    this.$expires = (typeof expires === 'number' ? expires : undefined);
     return _.merge(this, data || {});
 }

--- a/test/lib/Resource_test.js
+++ b/test/lib/Resource_test.js
@@ -31,5 +31,10 @@ describe('Resource', function() {
             this.resource.should.have.property('foo', this.data.foo);
             this.resource.should.have.property('bar', this.data.bar);
         });
+
+        it('does not have $expires property if not specified', function() {
+            var resource = new Resource(this.id, this.data);
+            resource.should.not.have.property('$expires');
+        });
     });
 });


### PR DESCRIPTION
When a resource is created that should not be cached, the `$expires` property was being set to `0`. However, the client is treating `0` as "cache this forever". To ensure that uncacheable resources are not cached, we can omit the `$expires` property altogether from the response.
