### PR TITLE
Adds support for query param validation and documentation

### DIFF
--- a/demo/schemas/user-collection.js
+++ b/demo/schemas/user-collection.js
@@ -7,6 +7,20 @@ module.exports = {
     description: 'A collection of users.',
     type: 'object',
     properties: {
+        limit: {
+            type: 'integer',
+            minimum: 1,
+            maximum: 100,
+            sample: 10
+        },
+        offset: {
+            type: 'integer',
+            minimum: 0,
+            sample: 0
+        },
+        search: {
+            type: 'string'
+        },
         items: {
             type: 'array',
             items: userSchema // Each item in the collection is a user, so reuse the userSchema here

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -135,7 +135,7 @@ Collection.prototype.setExpires = function(expires) {
         throw new Error("Expecting expires to be 0 or greater");
     }
 
-    if (type !== 'number' && type !== undefined) {
+    if (type !== 'number' && type !== 'undefined') {
         throw new Error("Expecting expires to be a number or undefined, got " + typeof expires);
     }
 
@@ -168,7 +168,7 @@ Collection.prototype.setTotal = function(total) {
         throw new Error("Expecting total to be 0 or greater");
     }
 
-    if (type !== 'number' && type !== undefined) {
+    if (type !== 'number' && type !== 'undefined') {
         throw new Error("Expecting total to be a number or undefined, got " + typeof total);
     }
 
@@ -199,7 +199,7 @@ Collection.prototype.setLimit = function(limit) {
         throw new Error("Expecting limit to be 0 or greater");
     }
 
-    if (type !== 'number' && type !== undefined) {
+    if (type !== 'number' && type !== 'undefined') {
         throw new Error("Expecting limit to be a number or undefined, got " + type);
     }
 
@@ -230,7 +230,7 @@ Collection.prototype.setOffset = function(offset) {
         throw new Error("Expecting offset to be 0 or greater");
     }
 
-    if (type !== 'number' && type !== undefined) {
+    if (type !== 'number' && type !== 'undefined') {
         throw new Error("Expecting offset to be a number or undefined, got " + type);
     }
 

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -2,6 +2,7 @@ var libUrl = require('url');
 var _ = require('lodash');
 var Resource = require('./Resource');
 var validationErrors = require('./models/validationErrors');
+var jsen = require('jsen');
 
 module.exports = Request;
 
@@ -76,6 +77,10 @@ Request.prototype.isOptions = function() {
     return this._method === Request.METHOD_OPTIONS;
 };
 
+Request.prototype.isGet = function() {
+    return this._method === Request.METHOD_GET;
+};
+
 Request.prototype.setParams = function(params) {
     this._params = params;
     return this;
@@ -111,6 +116,99 @@ Request.prototype.setQuery = function(query, value) {
 Request.prototype.getQuery = function(query) {
     return this._url.query.hasOwnProperty(query) ? this._url.query[query] : undefined;
 };
+
+/**
+ * Validates the query with the provided schema.
+ * Query parameters that are not included in the schema are ignored.
+ * Query parameters that are defined as type "integer" or "number" are converted accordingly.
+ * Returns a validation object with two properties:
+ *   - boolean valid -- true if the query parameters are valid
+ *   - array errors -- array of properties that are in error, if any
+ *
+ * @param object schema - a schema in json-schema format.
+ * @return object - validation result
+ */
+Request.prototype.validateQuery = function(schema, defaults) {
+    // Nothing to validate if the schema is not an object (rare)
+    if (!schema.properties) {
+        // Clear out existing query params -- they must be in the schema to access them.
+        this.setQueries({});
+        return {
+            valid: true,
+            errors: []
+        };
+    }
+
+    // Build new query object based on defaults
+    var query = _.assign({}, defaults);
+
+    // Validate query with schema
+    var validate = jsen(schema);
+
+    for (var key in query) {
+        // Skip prototype properties, if any
+        if (!query.hasOwnProperty(key)) continue;
+
+        // Skip properties that are not in the schema
+        if (!schema.properties.hasOwnProperty(key)) continue;
+
+        if (defaults[key] === '') {
+            // Empty string in defaults means no default, i.e. undefined
+            query[key] = undefined;
+        }
+
+        var value = this.getQuery(key);
+        if (typeof value === 'undefined' || value === '') {
+            continue;
+        }
+
+        // We have to do isNaN checks here because NaN can cause
+        // false validation success, because:
+        //
+        // 1) (typeof NaN === 'number') evaluates to `true` and
+        // 2) (NaN < 1) evaluates to `false`
+        switch (schema.properties[key].type) {
+            case 'integer':
+                value = parseInt(value);
+                if (isNaN(value)) return typeError(key);
+                break;
+
+            case 'number':
+                value = parseFloat(value);
+                if (isNaN(value)) return typeError(key);
+                break;
+        }
+
+        query[key] = value;
+    }
+
+    var valid = validate(query);
+    this.setQueries(query);
+
+    if (true === valid) {
+        return {
+            valid: true,
+            errors: []
+        };
+    } else {
+        return {
+            valid: false,
+            errors: validate.errors
+        };
+    }
+};
+
+function typeError(key) {
+    return {
+        valid: false,
+        errors: [
+            {
+                path: key,
+                keyword: 'type'
+            }
+        ]
+    };
+}
 
 Request.prototype.setResourceId = function(resourceId) {
     if (!_.isString(resourceId)) {

--- a/lib/Router.js
+++ b/lib/Router.js
@@ -15,6 +15,7 @@ var validationErrors = require('./models/validationErrors');
 var Resource = require('./Resource');
 var Collection = require('./Collection');
 var CollectionCache = require('./CollectionCache');
+var querystring = require('querystring');
 
 module.exports = Router;
 
@@ -29,15 +30,25 @@ util.inherits(Router, EventEmitter);
 /**
  * Registers a route for the API.
  *
- * @param string pattern - URL pattern for matching requests
+ * @param string|array pattern - URL pattern for matching requests, or an array with pattern and query string config
  * @param object schema - JSON Schema
  * @param object handlers - Callback functions to support the various HTTP verbs
  */
-Router.prototype.route = function(pattern, schema, handlers) {
+Router.prototype.route = function(patternConfig, schema, handlers) {
     // Validate the schema
     var isSchemaValid = validateSchema(schema);
     if (!isSchemaValid) {
         throw new Error("Invalid schema");
+    }
+
+    var pattern;
+    var query;
+    if (Array.isArray(patternConfig)) {
+        pattern = patternConfig[0];
+        query = querystring.parse(patternConfig[1]);
+    } else {
+        pattern = patternConfig;
+        query = {};
     }
 
     // Generate a regex to match URLs
@@ -61,12 +72,46 @@ Router.prototype.route = function(pattern, schema, handlers) {
         }
     });
 
+    // Ensure numbers are converted to int/float for query defaults
+    for (var queryParam in query) {
+        // Skip prototype properties, if any
+        if (!query.hasOwnProperty(queryParam)) continue;
+
+        if (!schema.properties) {
+            throw new Error("Query parameters requires an object schema with properties.");
+        }
+
+        if (!schema.properties.hasOwnProperty(queryParam)) {
+            throw new Error("Unexpected query param " + queryParam + " not found in schema.");
+        }
+
+        if ('' === query[queryParam]) {
+            // No default
+            continue;
+        }
+
+        switch (schema.properties[queryParam].type) {
+            case 'integer':
+                query[queryParam] = parseInt(query[queryParam]);
+                break;
+
+            case 'number':
+                query[queryParam] = parseFloat(query[queryParam]);
+                break;
+        }
+
+        if (isNaN(query[queryParam])) {
+            throw new Error("Query param " + queryParam + " contains invalid default value.");
+        }
+    }
+
     this._routes.push({
         pattern: pattern,
         schema: schema,
         handlers: normalizedHandlers,
         regex: regex,
-        keys: keys
+        keys: keys,
+        query: query
     });
 
     return this;
@@ -131,6 +176,7 @@ function documentRoute(route) {
     return Promise.resolve({
         pattern: route.pattern,
         methods: methods,
+        query: route.query,
         schema: route.schema
     });
 };
@@ -198,6 +244,35 @@ Router.prototype.handle = function(request, connection) {
     // Support OPTIONS
     if (request.isOptions()) {
         return Promise.resolve(documentRoute(route));
+    }
+
+    // Validate query parameters for GET requests
+    if (request.isGet()) {
+        var validation = request.validateQuery(route.schema, route.query);
+
+        if (!validation.valid) {
+            emit.call(this, 'api:error', request, null, timeStart);
+
+            // Get the first error and make sure to get the base property name (e.g. if an array of values is needs
+            // to validate to an enum and the second one doesn't validate successfully, it returns propertyName.1 -
+            // this will shorten it just to propertyName.
+            var error = validation.errors[0];
+            var propertyName = '';
+
+            if (error.path) {
+                propertyName = error.path.split('.')[0];
+            }
+
+            var code = validationErrors.default.code;
+            var message = validationErrors.default.message;
+
+            if (error.keyword && validationErrors[error.keyword]) {
+                code = validationErrors[error.keyword].code;
+                message = validationErrors[error.keyword].message;
+            }
+
+            return request.propertyError(propertyName, code, 422, message);
+        }
     }
 
     // Prepare request
@@ -558,7 +633,6 @@ var respondDocs = function(res) {
  * @return function
  */
 Router.prototype.middleware = function(options) {
-    var querystring = require('querystring');
     var config = _.assign({
         basePath: '/'              // Allow APIs to be accessible from a configured base path
     }, options || {});

--- a/lib/views/docs.jade
+++ b/lib/views/docs.jade
@@ -9,8 +9,11 @@
 
             case 'integer':
             case 'number':
-                var min = details.minimum;
-                var max = details.maximum;
+                var min = parseInt(details.minimum);
+                var max = parseInt(details.maximum);
+                if (isNaN(min) && isNaN(max)) return 123;
+                if (isNaN(min) && !isNaN(max)) return max;
+                if (!isNaN(min) && isNaN(max)) return min;
                 return Math.ceil(Math.random() * ((max || 100) - min)) + min;
 
             case 'boolean':
@@ -61,7 +64,7 @@ mixin props(properties)
                             else
                                 dd= details[key]
 
-mixin resource(pattern, schema, methods)
+mixin resource(pattern, schema, methods, query)
     h2
         = schema.title || pattern
         span(class="type type-#{schema.type}")= schema.type
@@ -78,6 +81,15 @@ mixin resource(pattern, schema, methods)
             each method in ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']
                 if -1 !== methods.indexOf(method)
                     span.method(class="method-#{method.toLowerCase()}")= method
+
+    if query
+        h3.query
+            | GET Query Parameters:
+            each value, key in query
+                span.query-param
+                    = key
+                    if value !== ''
+                        span.query-param-default= ' (' + value + ')'
 
     if schema.properties
         h3 Properties:
@@ -166,6 +178,21 @@ html
                 border-radius: 0.35em;
                 border: 2px solid rgba(255, 255, 255, 0.75);
                 font-family: monaco, monospace;
+                box-shadow: 0 0.3rem 0.2rem -0.2rem rgba(0, 0, 0, 0.25),
+                    inset 0 2em 1.5em -1em rgba(255, 255, 255, 0.25);
+            }
+
+            .query-param{
+                display: inline-block;
+                margin: 0 0 0 0.5em;
+                padding: 0.25em 0.5em;
+                color: #fff;
+                font-weight: bold;
+                font-size: 0.85rem;
+                border-radius: 0.35em;
+                border: 2px solid rgba(255, 255, 255, 0.75);
+                font-family: monaco, monospace;
+                background: #3a3;
                 box-shadow: 0 0.3rem 0.2rem -0.2rem rgba(0, 0, 0, 0.25),
                     inset 0 2em 1.5em -1em rgba(255, 255, 255, 0.25);
             }
@@ -317,8 +344,9 @@ html
                 - pattern = route.pattern
                 - schema = route.schema
                 - methods = route.methods
+                - query = route.query
                 .resource(id=route.pattern)
-                    +resource(pattern, schema, methods)
+                    +resource(pattern, schema, methods, query)
 
                     h3.sample Sample Response:
                     pre.response


### PR DESCRIPTION
To specify the query parameters that are available in `GET` requests, add them to your route definition:

``` js
router.route(['/users', 'limit=10&offset=0&search'], userCollectionSchema, callbackMap);
```

The Monocle framework will use this information for the following purposes:
1. To improve the automated documentation
2. To validate incoming query params
3. To convert query param `string`s to `integer` and `float` according to the schema
4. Fallback to defaults if provided query string param is not provided.

**GET Query Parameters in auto-generated docs (default value, if any, will be in parenthesis)**
![screen shot 2016-01-27 at 2 52 30 pm](https://cloud.githubusercontent.com/assets/308786/12631408/047d50da-c506-11e5-8794-ca2500959147.png)

**OPTIONS request**
![screen shot 2016-01-27 at 2 53 05 pm](https://cloud.githubusercontent.com/assets/308786/12631416/0d384e8c-c506-11e5-8678-cca7c7514c6c.png)

**Sample Error: `/users?limit=0`**
<img width="489" alt="screen shot 2016-01-26 at 10 11 42 pm" src="https://cloud.githubusercontent.com/assets/308786/12605472/2ef6b590-c47a-11e5-89aa-9570fc078857.png">

**Sample Error: `/users?limit=1000`**
<img width="486" alt="screen shot 2016-01-26 at 10 11 54 pm" src="https://cloud.githubusercontent.com/assets/308786/12605474/3afd7ab8-c47a-11e5-89a2-602a5c0420f3.png">

**Sample Error: `/users?limit=abc`**
<img width="413" alt="screen shot 2016-01-26 at 10 11 23 pm" src="https://cloud.githubusercontent.com/assets/308786/12605478/49ae2c56-c47a-11e5-8547-014bd9baa7e1.png">
