### PR TITLE
WTF-15738 Support file uploads.

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -13,6 +13,7 @@
     "body-parser": "1.13.3",
     "connect": "3.4.0",
     "lodash": "3.10.1",
-    "method-override": "2.3.5"
+    "method-override": "2.3.5",
+    "serve-static": "1.10.2"
   }
 }

--- a/demo/schemas/photo.js
+++ b/demo/schemas/photo.js
@@ -28,6 +28,10 @@ module.exports = {
             description: 'A user-supplied caption that describes this photo.',
             type: 'string',
             sample: 'My awesome picture!'
+        },
+        photo: {
+            description: 'Photo',
+            type: 'file'
         }
     }
 };

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -4,6 +4,8 @@ var SchemaFilter = require('./SchemaFilter');
 var Resource = require('./Resource');
 var validationErrors = require('./models/validationErrors');
 var jsen = require('jsen');
+var Busboy = require('busboy');
+var Promise = require('bluebird');
 
 module.exports = Request;
 
@@ -13,6 +15,8 @@ function Request(url, router, connection) {
     this._connection = connection;
     this._params = {};
     this._method = Request.METHOD_GET;
+    this._schema = null;
+    this._stream = null;
 }
 
 Request.METHOD_GET      = 'GET';
@@ -30,6 +34,12 @@ Request.ALL_METHODS = [
     Request.METHOD_DELETE,
     Request.METHOD_OPTIONS
 ];
+
+// Upload validation errors
+Request.ERROR_UPLOAD_TOO_LARGE              = 'ERROR_UPLOAD_TOO_LARGE';
+Request.ERROR_UPLOAD_TOO_SMALL              = 'ERROR_UPLOAD_TOO_SMALL';
+Request.ERROR_UPLOAD_MIME_TYPE              = 'ERROR_UPLOAD_MIME_TYPE';
+Request.ERROR_UPLOAD_NOT_FOUND              = 'ERROR_UPLOAD_NOT_FOUND';
 
 Request.prototype.setUrl = function(url) {
     this._url = libUrl.parse(url, true);
@@ -255,6 +265,15 @@ Request.prototype.isCollection = function(schema) {
     );
 }
 
+Request.prototype.setSchema = function(schema) {
+    this._schema = schema;
+    return this;
+};
+
+Request.prototype.getSchema = function() {
+    return this._schema;
+};
+
 Request.prototype.propertyError = function(property, errorCode, httpStatusCode, message) {
     httpStatusCode = parseInt(httpStatusCode, 10) || 400;
     var httpErrorString = this._router._httpStatusCodes.lookupByCode(httpStatusCode);
@@ -310,3 +329,240 @@ Request.prototype.propertyError = function(property, errorCode, httpStatusCode, 
         });
     }.bind(this));
 };
+
+/**
+ * Lazy loads and returns a streamable interface powered by Busboy.
+ * The streamable interface allows route callbacks to stream uploaded data
+ * and write it to the disk or network as it's being uploaded.
+ *
+ * The stream emits the `file` event, which provides a file stream to the callback function.
+ * See `Request.prototype.getUpload` for an example of how to process uploads.
+ *
+ * @throws      if the request does not have the `Content-Type: multipart/form-data` header,
+ *              or if the boundary is missing.
+ * @return      Busboy - @see https://github.com/mscdex/busboy
+ */
+Request.prototype.getStream = function() {
+    if (null === this._stream) {
+        this._stream = new Busboy({
+            headers: this._connection.raw.req.headers
+        });
+        this._connection.raw.req.pipe(this._stream);
+
+        validateUploads.call(this);
+    }
+    return this._stream;
+};
+
+function validateUploads() {
+    var schema = this.getSchema();
+    if (!schema) return;
+
+    var stream = this.getStream();
+    var isMimeTypeValid = null;
+
+    stream.on('file', function(fieldName, file, fileName, encoding, mimeType) {
+        var maxSize = schema.properties[fieldName].maxSize;
+        var size = 0;
+
+        var validate = function(data) {
+            // Validate the meme type as soon as first data comes,
+            // otherwise we risk emitting this event too early
+            if (null === isMimeTypeValid) {
+                isMimeTypeValid = validateMimeType(mimeType, schema.properties[fieldName].mimeTypes);
+
+                if (!isMimeTypeValid) {
+                    file.emit(
+                        'invalid',
+                        'Uploaded data for field name ' + fieldName + ' has invalid mime type ' + mimeType + '.',
+                        Request.ERROR_UPLOAD_MIME_TYPE
+                    );
+
+                    // No need to continue validating, we already know the mime type is bad.
+                    file.removeListener('data', validate);
+                    return;
+                }
+            }
+
+            size += data.length;
+
+            if (size > maxSize) {
+                file.emit(
+                    'invalid',
+                    'Uploaded data for field name ' + fieldName + ' is larger than allowed maximum size of ' + maxSize + ' bytes.',
+                    Request.ERROR_UPLOAD_TOO_LARGE
+                );
+
+                // Stop checking the size for this file
+                file.removeListener('data', validate);
+            }
+        };
+
+        file.on('data', validate);
+    });
+}
+
+function validateMimeType(mimeType, allowedMimeTypes) {
+    if (!mimeType) {
+        return false;
+    }
+
+    for (var i = 0, len = allowedMimeTypes.length; i < len; i++) {
+        var regex = allowedMimeTypes[i];
+        regex = regex.replace('*', '::MATCHANY::');
+        regex = escapeRegExp(regex);
+        regex = regex.replace('::MATCHANY::', '[^/]+');
+        regex = new RegExp('^' + regex + '$', 'i');
+
+        if (null === mimeType.match(regex)) {
+            return false;
+        }
+    }
+
+    // Assume true if we didn't fail in the loop above
+    return true;
+}
+
+// Borrowed from http://stackoverflow.com/questions/3446170/escape-string-for-use-in-javascript-regex
+function escapeRegExp(str) {
+  return str.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
+}
+
+/**
+ * Returns a promise that resolves with the first upload that matches the provided field name.
+ * Rejects promise if no uploads were found matching the field name.
+ *
+ * @return Promise
+ */
+Request.prototype.getUpload = function(field) {
+    return new Promise(function(resolve, reject) {
+        var stream = this.getStream();
+        var found = false;
+        var invalid = false;
+
+        var onFile = function(uploadedFieldName, file, fileName, encoding, mimeType) {
+            if (field != uploadedFieldName) {
+                // Got an upload, but not for the field name we are looking for.
+                // Skip this upload, maybe the next one will be under the desired field name.
+                return;
+            }
+
+            found = true;
+
+            // Stop listening for file events; we have the file we want.
+            stream.removeListener('file', onFile);
+
+            // Aggregrate the data as it is streamed in
+            var chunks = [];
+
+            file.on('data', function(data) {
+                chunks.push(data)
+            });
+
+            file.on('invalid', function(errorMessage, errorReason) {
+                invalid = true;
+                reject(generateError(errorMessage, errorReason));
+            });
+
+            file.on('end', function() {
+                if (!invalid) {
+                    var upload = uploadContainer(uploadedFieldName, Buffer.concat(chunks), fileName, encoding, mimeType);
+                    resolve(upload);
+                }
+            });
+        };
+
+        stream.on('file', onFile);
+
+        stream.on('finish', function() {
+            if (!found && !invalid) {
+                reject(generateError('Did not find upload under field name ' + field + '.', Request.ERROR_UPLOAD_NOT_FOUND));
+            }
+        });
+    }.bind(this));
+};
+
+generateError = function(message, reason) {
+    var error = new Error(message);
+    error.reason = reason;
+    return error;
+}
+
+/**
+ * Returns a promise that resolves with an array of all uploads that match the provided field name,
+ * or all uploads if no field name is provided.
+ * Reject promise if no uploads were found matching field name, or no uploads at all when no field name is provided.
+ *
+ * @return Promise
+ */
+Request.prototype.getAllUploads = function(field) {
+    return new Promise(function(resolve, reject) {
+        var stream = this.getStream();
+        var found = [];
+        var invalid = false;
+
+        var onFile = function(uploadedFieldName, file, fileName, encoding, mimeType) {
+            if (field && field != uploadedFieldName) {
+                // Got an upload, but not under the field name we are looking for.
+                // Skip this upload, maybe the next one will be under the desired field name.
+                return;
+            }
+
+            // Aggregate the data as it is streamed in
+            var chunks = [];
+
+            file.on('data', function(data) {
+                chunks.push(data);
+            });
+
+            file.on('invalid', function(errorMessage, errorReason) {
+                invalid = true;
+                reject(generateError(errorMessage, errorReason));
+            });
+
+            file.on('end', function() {
+                var upload = uploadContainer(uploadedFieldName, Buffer.concat(chunks), fileName, encoding, mimeType);
+                found.push(upload);
+            });
+        };
+
+        stream.on('file', onFile);
+
+        stream.on('finish', function() {
+            if (invalid) {
+                // Promise is already rejected, nothing to do
+                return;
+            }
+
+            if (found.length) {
+                return resolve(found);
+            } else {
+                var message = field ?
+                    'Did not find any uploads under field name ' + field + '.' :
+                    'Did not find any uploads.';
+                return reject(generateError(message, Request.ERROR_UPLOAD_NOT_FOUND));
+            }
+        });
+    }.bind(this));
+};
+
+/**
+ * A simple wrapper for uploaded files.
+ *
+ * @param string fieldName - The name of the field this file was uploaded under
+ * @param Buffer buffer - A node Buffer containing the uploaded data
+ * @param string fileName - The original file name of the uploaded file (e.g. "me.png")
+ * @param string encoding - The encoding of the file (e.g. "7-bit")
+ * @param string mimeType - The mime type of the file (e.g. "image/png")
+ * @return object
+ */
+function uploadContainer(fieldName, buffer, fileName, encoding, mimeType) {
+    return {
+        buffer: buffer,
+        fieldName: fieldName,
+        encoding: encoding,
+        mimeType: mimeType,
+        fileName: fileName,
+        size: buffer.length
+    };
+}

--- a/lib/Router.js
+++ b/lib/Router.js
@@ -247,6 +247,9 @@ Router.prototype.handle = function(request, connection) {
     var match = matched.match;
     route = matched.route;
 
+    // Let the request know about the schema
+    request.setSchema(route.schema);
+
     // Support OPTIONS
     if (request.isOptions()) {
         return Promise.resolve(documentRoute(route));

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "bluebird": "2.9.34",
+    "busboy": "0.2.12",
     "jade": "1.11.0",
     "jsen": "0.6.0",
     "lodash": "3.10.1",

--- a/test/lib/Request_test.js
+++ b/test/lib/Request_test.js
@@ -1,5 +1,8 @@
 var Request = require('../../lib/Request');
 var Resource = require('../../lib/Resource');
+var Busboy = require('busboy');
+var EventEmitter = require('events').EventEmitter;
+var Promise = require('bluebird');
 
 describe('Request', function() {
     it('is a constructor', function() {
@@ -130,6 +133,7 @@ describe('Request', function() {
             expect(this.request.getResourceId()).to.be.undefined;
         });
     });
+
     describe('isCollection', function() {
         beforeEach(function() {
             this.request = new Request('/foo');
@@ -155,6 +159,7 @@ describe('Request', function() {
 
             this.request.isCollection(collectionSchema).should.be.true;
         });
+
         it('false if schema is not a collection', function() {
             var collectionSchema = {
                 type: 'object',
@@ -169,4 +174,652 @@ describe('Request', function() {
         });
     });
 
+    describe('binary uploads', function() {
+        beforeEach(function() {
+            this.router = null;
+            this.boundary = '---------------------BOUNDARY';
+            this.connection = {
+                raw: {
+                    req: {
+                        method: 'ANYTHING', // Technically any method is allowed
+                        headers: {
+                            'content-type': 'multipart/form-data; boundary=' + this.boundary
+                        },
+                        pipe: sinon.stub()
+                    }
+                }
+            };
+            this.schema = {
+                type: 'object',
+                properties: {
+                    photo: {
+                        type: 'file',
+                        mimeTypes: ['image/*'], // allowed mime types, supports wildcards
+                        // TODO: Support minSize somehow
+                        // minSize: 5, // minimum size in bytes
+                        maxSize: 20 // maximum size in bytes
+                    },
+                    audio: {
+                        type: 'file',
+                        mimeTypes: ['audio/*'],
+                        maxSize: 20
+                    }
+                }
+            };
+        });
+
+        describe('streaming API', function() {
+            it('is available on multipart requests', function() {
+                this.request = new Request('/foo', this.router, this.connection);
+                var stream = this.request.getStream();
+                stream.should.be.instanceOf(Busboy);
+            });
+
+            it('pipes request to stream', function() {
+                this.request = new Request('/foo', this.router, this.connection);
+                var stream = this.request.getStream();
+                this.connection.raw.req.pipe.calledWith(stream).should.be.true;
+            });
+
+            it('throws error on non-multipart requests', function() {
+                this.connection.raw.req.headers['content-type'] = 'application/json';
+                this.request = new Request('/foo', this.router, this.connection);
+                expect(function() {
+                    this.request.getStream();
+                }.bind(this)).to.throw();
+            });
+        });
+
+        describe('validation', function() {
+            describe('with valid upload', function() {
+                [
+                    'image/jpeg',       // jpeg OK
+                    'image/png',        // png OK
+                    'image/anything',   // schema accepts "image/*"
+                ].forEach(function(validMimeType) {
+                    it('does not emit error event with valid photo mime type: ' + validMimeType, function() {
+                        this.request = new Request('/foo', this.router, this.connection);
+                        this.request.setSchema(this.schema);
+
+                        var stream = this.request.getStream();
+                        var file = new EventEmitter();
+
+                        var errorSpy = sinon.spy();
+                        file.on('invalid', errorSpy);
+
+                        // Simulate sending the file
+                        stream.emit('file', 'photo', file, 'me.jpg', '7-bit', validMimeType);
+                        file.emit('data', new Buffer('123'));
+                        file.emit('data', new Buffer('☃'));
+                        file.emit('data', new Buffer('456'));
+                        file.emit('end');
+
+                        stream.emit('finish');
+                        errorSpy.called.should.be.false;
+                    });
+                });
+            });
+
+            describe('with invalid upload', function() {
+                describe.skip('photo too small', function() {
+                    it('emits error event', function(done) {
+                        this.request = new Request('/foo', this.router, this.connection);
+                        this.request.setSchema(this.schema);
+
+                        var stream = this.request.getStream();
+                        var file = new EventEmitter();
+
+                        var errorSpy = sinon.spy(function(message, reason) {
+                            message.should.equal('Uploaded data for field name photo is smaller than allowed minimum size of 5 bytes.');
+                            reason.should.equal(Request.ERROR_UPLOAD_TOO_SMALL);
+                            done();
+                        });
+                        file.on('invalid', errorSpy);
+
+                        // Simulate sending the file
+                        stream.emit('file', 'photo', file, 'me.jpg', '7-bit', 'image/jpeg');
+                        file.emit('data', new Buffer('1')); // upload is too small; < 5 bytes
+                        file.emit('end');
+
+                        stream.emit('finish');
+                        errorSpy.called.should.be.true;
+                    });
+                });
+
+                describe('photo too large', function() {
+                    it('emits error event', function(done) {
+                        this.request = new Request('/foo', this.router, this.connection);
+                        this.request.setSchema(this.schema);
+
+                        var stream = this.request.getStream();
+                        var file = new EventEmitter();
+
+                        var errorSpy = sinon.spy(function(error, reason) {
+                            error.should.equal('Uploaded data for field name photo is larger than allowed maximum size of 20 bytes.');
+                            reason.should.equal(Request.ERROR_UPLOAD_TOO_LARGE);
+                            done();
+                        });
+                        file.on('invalid', errorSpy);
+
+                        // Simulate sending the file
+                        stream.emit('file', 'photo', file, 'me.jpg', '7-bit', 'image/jpeg');
+                        file.emit('data', new Buffer('☃☃☃☃☃☃☃☃☃☃')); // upload is too large; > 20 bytes
+                        file.emit('end');
+
+                        stream.emit('finish');
+                        // errorSpy.called.should.be.true;
+                    });
+                });
+
+                [
+                    'audio/midi',   // totally wrong file type
+                    'images/png',   // "images" should be "image"
+                    'image',        // missing "/*"
+                    'png/image',    // backwards
+                    '',             // empty
+                    null,           // no mime type
+                ].forEach(function(invalidMimeType) {
+                    it('emits error event with invalid photo mime type: ' + invalidMimeType, function(done) {
+                        this.request = new Request('/foo', this.router, this.connection);
+                        this.request.setSchema(this.schema);
+
+                        var stream = this.request.getStream();
+                        var file = new EventEmitter();
+
+                        var errorSpy = sinon.spy(function(error, reason) {
+                            error.should.equal('Uploaded data for field name photo has invalid mime type ' + invalidMimeType + '.');
+                            reason.should.equal(Request.ERROR_UPLOAD_MIME_TYPE);
+                            done();
+                        });
+                        file.on('invalid', errorSpy);
+
+                        // Simulate sending the file
+                        stream.emit('file', 'photo', file, 'me.jpg', '7-bit', invalidMimeType);
+                        file.emit('data', new Buffer('☃☃☃')); // upload size is good
+                        file.emit('end');
+
+                        stream.emit('finish');
+                        errorSpy.called.should.be.true;
+                    });
+                });
+            });
+        });
+
+        describe('getUpload()', function() {
+            it('returns a promise', function() {
+                this.request = new Request('/foo', this.router, this.connection);
+                var promise = this.request.getUpload('foo');
+                promise.should.have.property('then');
+                promise.then.should.be.a('function');
+            });
+
+            it('returns a rejected promise on non-multipart requests', function() {
+                this.connection.raw.req.headers['content-type'] = 'application/json';
+                this.request = new Request('/foo', this.router, this.connection);
+
+                return this.request.getUpload('foo')
+                .then(function(anything) {
+                    throw new Error('Did not expect promise to resolve');
+                })
+                .catch(function(error) {
+                    error.message.should.contain('Unsupported content type');
+                });
+            });
+
+            it('resolves with an object containing a buffer of the upload contents', function() {
+                this.request = new Request('/foo', this.router, this.connection);
+                var stream = this.request.getStream();
+                var promise = this.request.getUpload('foo');
+                var file = new EventEmitter();
+
+                // Simulate sending the file
+                stream.emit('file', 'foo', file, 'me.jpg', '7-bit', 'image/jpeg');
+                file.emit('data', new Buffer('123'));
+                file.emit('data', new Buffer('☃'));
+                file.emit('data', new Buffer('456'));
+                file.emit('end');
+                stream.emit('finish');
+
+                return promise.then(function(upload) {
+                    upload.should.have.property('buffer');
+                    upload.buffer.toString('utf8').should.equal('123☃456');
+                });
+            });
+
+            it('resolves with an object containing the encoding of the upload', function() {
+                this.request = new Request('/foo', this.router, this.connection);
+                var stream = this.request.getStream();
+                var promise = this.request.getUpload('foo');
+                var file = new EventEmitter();
+
+                // Simulate sending the file
+                stream.emit('file', 'foo', file, 'me.jpg', '7-bit', 'image/jpeg');
+                file.emit('end');
+                stream.emit('finish');
+
+                return promise.then(function(upload) {
+                    upload.should.have.property('encoding', '7-bit');
+                });
+            });
+
+            it('resolves with an object containing the mime type of the upload', function() {
+                this.request = new Request('/foo', this.router, this.connection);
+                var stream = this.request.getStream();
+                var promise = this.request.getUpload('foo');
+                var file = new EventEmitter();
+
+                // Simulate sending the file
+                stream.emit('file', 'foo', file, 'me.jpg', '7-bit', 'image/jpeg');
+                file.emit('end');
+                stream.emit('finish');
+
+                return promise.then(function(upload) {
+                    upload.should.have.property('mimeType', 'image/jpeg');
+                });
+            });
+
+            it('resolves with an object containing the file name of the upload', function() {
+                this.request = new Request('/foo', this.router, this.connection);
+                var stream = this.request.getStream();
+                var promise = this.request.getUpload('foo');
+                var file = new EventEmitter();
+
+                // Simulate sending the file
+                stream.emit('file', 'foo', file, 'me.jpg', '7-bit', 'image/jpeg');
+                file.emit('end');
+                stream.emit('finish');
+
+                return promise.then(function(upload) {
+                    upload.should.have.property('fileName', 'me.jpg');
+                });
+            });
+
+            it('resolves with an object containing the field name of the upload', function() {
+                this.request = new Request('/foo', this.router, this.connection);
+                var stream = this.request.getStream();
+                var promise = this.request.getUpload('foo');
+                var file = new EventEmitter();
+
+                // Simulate sending the file
+                stream.emit('file', 'foo', file, 'me.jpg', '7-bit', 'image/jpeg');
+                file.emit('data', new Buffer('☃')); // 1 character, multiple bytes
+                file.emit('end');
+                stream.emit('finish');
+
+                return promise.then(function(upload) {
+                    upload.should.have.property('size', 3);
+                });
+            });
+
+            it('resolves with an object containing the size of the upload', function() {
+                this.request = new Request('/foo', this.router, this.connection);
+                var stream = this.request.getStream();
+                var promise = this.request.getUpload('foo');
+                var file = new EventEmitter();
+
+                // Simulate sending the file
+                stream.emit('file', 'foo', file, 'me.jpg', '7-bit', 'image/jpeg');
+                file.emit('end');
+                stream.emit('finish');
+
+                return promise.then(function(upload) {
+                    upload.should.have.property('fieldName', 'foo');
+                });
+            });
+
+            it('resolves with upload by specified name if multiple uploads are sent', function() {
+                this.request = new Request('/foo', this.router, this.connection);
+                var stream = this.request.getStream();
+                var promise = this.request.getUpload('foo2');
+
+                var file1 = new EventEmitter();
+                var file2 = new EventEmitter();
+                var file3 = new EventEmitter();
+
+                // Simulate sending the files
+                stream.emit('file', 'foo1', file1, 'me1.jpg', '7-bit', 'image/jpeg');
+                file1.emit('data', new Buffer('123'));
+                file1.emit('end');
+
+                stream.emit('file', 'foo2', file2, 'me2.jpg', '7-bit', 'image/jpeg');
+                file2.emit('data', new Buffer('456'));
+                file2.emit('end');
+
+                stream.emit('file', 'foo3', file3, 'me3.jpg', '7-bit', 'image/jpeg');
+                file3.emit('data', new Buffer('789'));
+                file3.emit('end');
+
+                stream.emit('finish');
+
+                return promise.then(function(upload) {
+                    upload.should.have.property('fileName', 'me2.jpg');
+                    upload.buffer.toString('utf8').should.equal('456');
+                });
+            });
+
+            it('resolves with first upload by specified name if multiple uploads are sent with the same name', function() {
+                this.request = new Request('/foo', this.router, this.connection);
+                var stream = this.request.getStream();
+                var promise = this.request.getUpload('foo');
+
+                var file1 = new EventEmitter();
+                var file2 = new EventEmitter();
+                var file3 = new EventEmitter();
+
+                // Simulate sending the files
+                stream.emit('file', 'foo', file1, 'me1.jpg', '7-bit', 'image/jpeg');
+                file1.emit('data', new Buffer('123'));
+                file1.emit('end');
+
+                stream.emit('file', 'bar', file2, 'me2.jpg', '7-bit', 'image/jpeg');
+                file2.emit('data', new Buffer('456'));
+                file2.emit('end');
+
+                stream.emit('file', 'foo', file3, 'me3.jpg', '7-bit', 'image/jpeg');
+                file3.emit('data', new Buffer('789'));
+                file3.emit('end');
+
+                stream.emit('finish');
+
+                return promise.then(function(upload) {
+                    upload.should.have.property('fileName', 'me1.jpg');
+                    upload.buffer.toString('utf8').should.equal('123');
+                });
+            });
+
+            it('rejects if no upload by the specified name is found by the time the request ends', function() {
+                this.request = new Request('/foo', this.router, this.connection);
+                var stream = this.request.getStream();
+                var promise = this.request.getUpload('foo');
+                var file = new EventEmitter();
+
+                // Simulate sending the file
+                stream.emit('file', 'not-foo', file, 'me.jpg', '7-bit', 'image/jpeg');
+                file.emit('end');
+                stream.emit('finish');
+
+                return promise.then(function() {
+                    throw new Error('Did not expect promise to resolve');
+                })
+                .catch(function(error) {
+                    error.message.should.contain('Did not find upload under field name foo');
+                });
+            });
+
+            describe('validation', function() {
+                describe('upload too large', function() {
+                    it('rejects promise', function() {
+                        this.request = new Request('/foo', this.router, this.connection);
+                        this.request.setSchema(this.schema);
+                        var stream = this.request.getStream();
+                        var promise = this.request.getUpload('photo');
+                        var file = new EventEmitter();
+
+                        // Simulate sending the file
+                        stream.emit('file', 'photo', file, 'me.jpg', '7-bit', 'image/jpeg');
+                        file.emit('data', new Buffer('☃☃☃☃☃☃☃☃☃☃'));
+                        file.emit('end');
+                        stream.emit('finish');
+
+                        return promise.then(function() {
+                            throw new Error('Did not expect promise to resolve');
+                        })
+                        .catch(function(error) {
+                            error.message.should.contain('Uploaded data for field name photo is larger than allowed maximum size of 20 bytes.');
+                            error.reason.should.equal(Request.ERROR_UPLOAD_TOO_LARGE);
+                        });
+                    });
+                });
+
+                describe('upload invalid mime type', function() {
+                    it('rejects promise', function() {
+                        this.request = new Request('/foo', this.router, this.connection);
+                        this.request.setSchema(this.schema);
+                        var stream = this.request.getStream();
+                        var promise = this.request.getUpload('photo');
+                        var file = new EventEmitter();
+
+                        // Simulate sending the file
+                        stream.emit('file', 'photo', file, 'me.jpg', '7-bit', 'audio/midi');
+                        file.emit('data', new Buffer('☃☃☃'));
+                        file.emit('end');
+                        stream.emit('finish');
+
+                        return promise.then(function() {
+                            throw new Error('Did not expect promise to resolve');
+                        })
+                        .catch(function(error) {
+                            error.message.should.contain('Uploaded data for field name photo has invalid mime type audio/midi.');
+                            error.reason.should.equal(Request.ERROR_UPLOAD_MIME_TYPE);
+                        });
+                    });
+                });
+
+                describe('mixed valid and invalid', function() {
+                    it('resolves and rejects each promise accordingly', function() {
+                        this.request = new Request('/foo', this.router, this.connection);
+                        this.request.setSchema(this.schema);
+                        var stream = this.request.getStream();
+                        var promise1 = this.request.getUpload('photo');
+                        var promise2 = this.request.getUpload('audio');
+                        var file1 = new EventEmitter();
+                        var file2 = new EventEmitter();
+
+                        // Simulate sending the files
+                        stream.emit('file', 'photo', file1, 'me.midi', '7-bit', 'audio/midi'); // wrong type
+                        file1.emit('data', new Buffer('☃☃☃'));
+                        file1.emit('end');
+
+                        stream.emit('file', 'audio', file2, 'me.midi', '7-bit', 'audio/midi'); // valid type
+                        file2.emit('data', new Buffer('☃☃☃'));
+                        file2.emit('end');
+
+                        stream.emit('finish');
+
+                        return Promise.all([promise1, promise2])
+                        .then(function(anything) {
+                             throw new Error('Did not expect promise to resolve');
+                        })
+                        .catch(function(anything) {
+                            promise1.isRejected().should.be.true;
+                            promise2.isFulfilled().should.be.true;
+                        });
+                    });
+                });
+            });
+        });
+
+        describe('getAllUploads()', function() {
+            it('returns a promise', function() {
+                this.request = new Request('/foo', this.router, this.connection);
+                var promise = this.request.getAllUploads();
+                promise.should.have.property('then');
+                promise.then.should.be.a('function');
+            });
+
+            it('returns a rejected promise on non-multipart requests', function() {
+                this.connection.raw.req.headers['content-type'] = 'application/json';
+                this.request = new Request('/foo', this.router, this.connection);
+
+                return this.request.getAllUploads()
+                .then(function(anything) {
+                    throw new Error('Did not expect promise to resolve');
+                })
+                .catch(function(error) {
+                    error.message.should.contain('Unsupported content type');
+                });
+            });
+
+            describe('without arguments', function() {
+                it('resolves with an array of objects containing buffers of the uploaded contents', function() {
+                    this.request = new Request('/foo', this.router, this.connection);
+                    var stream = this.request.getStream();
+                    var promise = this.request.getAllUploads();
+                    var file1 = new EventEmitter();
+                    var file2 = new EventEmitter();
+                    var file3 = new EventEmitter();
+
+                    // Simulate sending the file
+                    // Simulate sending the files
+                    stream.emit('file', 'foo1', file1, 'me1.jpg', '7-bit', 'image/jpeg');
+                    file1.emit('data', new Buffer('123'));
+                    file1.emit('end');
+
+                    stream.emit('file', 'foo2', file2, 'me2.png', '7-bit', 'image/png');
+                    file2.emit('data', new Buffer('456'));
+                    file2.emit('end');
+
+                    stream.emit('file', 'foo3', file3, 'me3.gif', '7-bit', 'image/gif');
+                    file3.emit('data', new Buffer('789'));
+                    file3.emit('end');
+
+                    stream.emit('finish');
+
+                    return promise.then(function(uploads) {
+                        uploads.should.be.an('array');
+                        uploads.should.have.lengthOf(3);
+
+                        // Validate zeroth upload
+                        uploads[0].should.contain({
+                            fieldName: 'foo1',
+                            encoding: '7-bit',
+                            mimeType: 'image/jpeg',
+                            fileName: 'me1.jpg'
+                        });
+                        uploads[0].should.have.property('buffer');
+                        uploads[0].buffer.toString('utf8').should.equal('123');
+
+                        // Validate first upload
+                        uploads[1].should.contain({
+                            fieldName: 'foo2',
+                            encoding: '7-bit',
+                            mimeType: 'image/png',
+                            fileName: 'me2.png'
+                        });
+                        uploads[1].should.have.property('buffer');
+                        uploads[1].buffer.toString('utf8').should.equal('456');
+
+                        // Validate second upload
+                        uploads[2].should.contain({
+                            fieldName: 'foo3',
+                            encoding: '7-bit',
+                            mimeType: 'image/gif',
+                            fileName: 'me3.gif'
+                        });
+                        uploads[2].should.have.property('buffer');
+                        uploads[2].buffer.toString('utf8').should.equal('789');
+                    });
+                });
+
+                it('rejects promise if no uploads were found', function() {
+                    this.request = new Request('/foo', this.router, this.connection);
+
+                    var stream = this.request.getStream();
+                    var promise = this.request.getAllUploads();
+
+                    // Simulate no uploads, finish stream now
+                    stream.emit('finish');
+
+                    return promise
+                    .then(function(anything) {
+                        throw new Error('Did not expect promise to resolve');
+                    })
+                    .catch(function(error) {
+                        error.message.should.contain('Did not find any uploads');
+                    });
+                });
+            });
+
+            describe('with arguments', function() {
+                it('resolves with an array of objects containing buffers of the uploaded contents for each upload that matched the specified field name', function() {
+                    this.request = new Request('/foo', this.router, this.connection);
+                    var stream = this.request.getStream();
+                    var promise = this.request.getAllUploads('foo');
+                    var file1 = new EventEmitter();
+                    var file2 = new EventEmitter();
+                    var file3 = new EventEmitter();
+
+                    // Simulate sending the file
+
+                    // Matches field name
+                    stream.emit('file', 'foo', file1, 'me1.jpg', '7-bit', 'image/jpeg');
+                    file1.emit('data', new Buffer('123'));
+                    file1.emit('end');
+
+                    // Does not match field name
+                    stream.emit('file', 'bar', file2, 'me2.png', '7-bit', 'image/png');
+                    file2.emit('data', new Buffer('456'));
+                    file2.emit('end');
+
+                    // Also matches field name
+                    stream.emit('file', 'foo', file3, 'me3.gif', '7-bit', 'image/gif');
+                    file3.emit('data', new Buffer('789'));
+                    file3.emit('end');
+
+                    stream.emit('finish');
+
+                    return promise.then(function(uploads) {
+                        uploads.should.be.an('array');
+                        uploads.should.have.lengthOf(2);
+
+                        // Validate zeroth upload
+                        uploads[0].should.contain({
+                            fieldName: 'foo',
+                            encoding: '7-bit',
+                            mimeType: 'image/jpeg',
+                            fileName: 'me1.jpg'
+                        });
+                        uploads[0].should.have.property('buffer');
+                        uploads[0].buffer.toString('utf8').should.equal('123');
+
+                        // Validate first upload
+                        uploads[1].should.contain({
+                            fieldName: 'foo',
+                            encoding: '7-bit',
+                            mimeType: 'image/gif',
+                            fileName: 'me3.gif'
+                        });
+                        uploads[1].should.have.property('buffer');
+                        uploads[1].buffer.toString('utf8').should.equal('789');
+                    });
+                });
+
+                it('rejects promise if no uploads were found for provided field name', function() {
+                    this.request = new Request('/foo', this.router, this.connection);
+                    var stream = this.request.getStream();
+                    var promise = this.request.getAllUploads('unknown');
+                    var file1 = new EventEmitter();
+                    var file2 = new EventEmitter();
+                    var file3 = new EventEmitter();
+
+                    // Simulate sending the file
+
+                    // Matches field name
+                    stream.emit('file', 'foo', file1, 'me1.jpg', '7-bit', 'image/jpeg');
+                    file1.emit('data', new Buffer('123'));
+                    file1.emit('end');
+
+                    // Does not match field name
+                    stream.emit('file', 'bar', file2, 'me2.png', '7-bit', 'image/png');
+                    file2.emit('data', new Buffer('456'));
+                    file2.emit('end');
+
+                    // Also matches field name
+                    stream.emit('file', 'baz', file3, 'me3.gif', '7-bit', 'image/gif');
+                    file3.emit('data', new Buffer('789'));
+                    file3.emit('end');
+
+                    stream.emit('finish');
+
+                    return promise
+                    .then(function(anything) {
+                        throw new Error('Did not expect promise to resolve');
+                    })
+                    .catch(function(error) {
+                        error.message.should.contain('Did not find any uploads under field name unknown');
+                    });
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
Allows routes to access upload data.
- [x] Streaming API to process uploads as they are being sent.
- [x] Convenience function `request.getUpload(name)` to get a single upload by name. Exposes mime type, original filename, encoding, form field name, and a buffer to access binary data.
- [x] Convenience function `request.getAllUploads(name)` to get multiple uploads by the same name, or all file uploads.
- [x] Validates mime type and maximum size with schema.

When using the convenience functions, the returned promise will be rejected if the upload fails validation. When using the streaming API, you'll need to listen for the `invalid` event on the `file` object:

```
return new Promise(function(resolve, reject) {
  var stream = request.getStream();

  stream.on('file', function(uploadedFieldName, file, fileName, encoding, mimeType) {
    file.on('invalid', function(error, reason) {
      reject('Invalid upload');
    });

    /* ... */
  });
});
```
