### PR TITLE
Adds support for registering post-route hooks to modify responses

### DIFF
--- a/lib/Router.js
+++ b/lib/Router.js
@@ -22,6 +22,7 @@ module.exports = Router;
 function Router() {
     this._routes = [];
     this._httpStatusCodes = new HttpStatusCodes();
+    this._postRoutes = [];
 }
 
 // Extend EventEmitter
@@ -120,6 +121,11 @@ Router.prototype.route = function(patternConfig, schema, handlers) {
         query: query
     });
 
+    return this;
+};
+
+Router.prototype.postRoute = function(callback) {
+    this._postRoutes.push(callback);
     return this;
 };
 
@@ -489,6 +495,7 @@ Router.prototype.handle = function(request, connection) {
             return result;
         }.bind(this));
     }.bind(this))
+    .then(applyPostRoutes.bind(this))
     .catch(function(error) {
         // Validate error
         var validate = jsen(errorSchema);
@@ -502,6 +509,14 @@ Router.prototype.handle = function(request, connection) {
         // Forward error
         return Promise.reject(error);
     });
+};
+
+var applyPostRoutes = function(body) {
+    var result = Promise.resolve(body);
+    this._postRoutes.forEach(function(postRoute) {
+        result = result.then(postRoute);
+    });
+    return result;
 };
 
 var remove$Props = function(resource) {


### PR DESCRIPTION
## Usage:

``` js
router.postRoute(function(resource) {
  resource.$tag = new Date();
  return resource;
});
```

With the above postRoute hook, **all** API responses will now contain the `$tag` property set to the current date.

Promises are also supported:

``` js
router.postRoute(function(resource) {
  return myService.getTag()
  .then(function(tag) {
    resource.$tag = tag;
    return resource;
  });
});
```

If multiple postRoute hooks are registered, they will be run in FIFO order, receiving the resolved value from the previous postRoute hook.
