### PR TITLE
Allows symlinks to be mutated after resolving.

### DIFF
--- a/lib/Symlink.js
+++ b/lib/Symlink.js
@@ -2,8 +2,39 @@ module.exports = Symlink;
 
 function Symlink(link) {
     this.$link = link;
+
+    // Using defineProperty to hide this property from JSON output
+    Object.defineProperty(this, 'mutators', {
+        value: []
+    });
 }
 
 Symlink.prototype.resolve = function(connection) {
-    return connection.get(this.$link);
-}
+    return this.mutators.reduce(function(prev, mutator) {
+        return prev[mutator.type](mutator.handler);
+    }, connection.get(this.$link));
+};
+
+Symlink.prototype.then = function(handler) {
+    this.mutators.push({
+        type: 'then',
+        handler: handler
+    });
+    return this;
+};
+
+Symlink.prototype.catch = function(handler) {
+    this.mutators.push({
+        type: 'catch',
+        handler: handler
+    });
+    return this;
+};
+
+Symlink.prototype.finally = function(handler) {
+    this.mutators.push({
+        type: 'finally',
+        handler: handler
+    });
+    return this;
+};

--- a/test/lib/Symlink_test.js
+++ b/test/lib/Symlink_test.js
@@ -24,9 +24,57 @@ describe('Symlink', function() {
 
         it('makes GET request with connection', function() {
             return this.symlink.resolve(this.connection)
-            then(function(result) {
+            .then(function(result) {
                 this.connection.get.calledWith(this.id).should.be.true;
             }.bind(this));
+        });
+    });
+
+    describe('post resolve mutator', function() {
+        beforeEach(function() {
+            this.id = '/foo/123';
+            this.symlink = new Symlink(this.id);
+            this.connection = {
+                get: sinon.stub().returns(Promise.resolve({
+                    foo: 'test foo'
+                }))
+            };
+        });
+
+        it('can mutate resource via .then()', function() {
+            this.symlink.then(function(result) {
+                result.foo = 'updated';
+                return result;
+            });
+
+            return this.symlink.resolve(this.connection)
+            .then(function(result) {
+                result.foo.should.equal('updated');
+            }.bind(this));
+        });
+
+        it('can recover from errors via .catch()', function(done) {
+            this.connection.get.returns(Promise.reject('some error'));
+
+            this.symlink.catch(function(error) {
+                return {
+                    foo: 'sensible default'
+                };
+            });
+
+            this.symlink.resolve(this.connection)
+            .then(function(result) {
+                result.foo.should.equal('sensible default');
+                done();
+            }.bind(this));
+        });
+
+        it('can run code regardless of result', function(done) {
+            this.symlink.finally(function(error) {
+                done();
+            });
+
+            this.symlink.resolve(this.connection);
         });
     });
 });


### PR DESCRIPTION
Uses promise methods like `.then(result)`, `.catch(error)`, and `.finally()`.
