### PR TITLE
Improve symlink resolution

### DIFF
--- a/lib/Router.js
+++ b/lib/Router.js
@@ -16,6 +16,8 @@ var Resource = require('./Resource');
 var OffsetPaginator = require('./OffsetPaginator');
 var CollectionCache = require('./CollectionCache');
 var querystring = require('querystring');
+var merge = require('./util/merge');
+var debug = require('debug')('monocle-api:router');
 
 module.exports = Router;
 
@@ -425,26 +427,11 @@ Router.prototype.handle = function(request, connection) {
 
     return Promise.all(callbacks)
     .then(function(results) {
-        results = results.map(function(result) {
-            // Multiple resources returned
-            if (_.isArray(result)) {
-                return result.map(function(r) {
-                    // Convert to an object if an instance
-                    return (_.isObject(r)) ? _.merge({}, r) : r;
-                });
-            } else if (_.isObject(result)) {
-                return _.merge({}, result);
-            }
-
-            return result;
-        });
+        debug('got results from callbacks', results);
 
         // Merges results from different functions
-        var result = _.merge.apply(null, results.concat([function Customizer(a, b) {
-            if (a instanceof Resource || b instanceof Resource) {
-                return _.merge(a, b);
-            }
-        }]));
+        var result = merge.apply(null, results);
+        debug('merged result from all callbacks', typeof result, result);
 
         // Support internal errors
         if (result.$internalError == 'missing') {
@@ -502,7 +489,7 @@ Router.prototype.handle = function(request, connection) {
             // Emit success event
             emit.call(this, 'api:success', request, route, timeStart);
 
-            return result;
+            return deleteUndefinedProperties(result, true);
         }.bind(this));
     }.bind(this))
     .then(applyPostRoutes.bind(this))
@@ -542,6 +529,18 @@ var remove$Props = function(resource) {
         }
     });
 };
+
+function deleteUndefinedProperties(test, recurse) {
+    for (var i in test) {
+        if (typeof test[i] === 'undefined') {
+            delete test[i];
+        } else if (recurse && typeof test[i] === 'object') {
+            deleteUndefinedProperties(test[i], recurse);
+        }
+    }
+
+    return test;
+}
 
 var restrictProps = function(resource, props) {
     if (resource.hasOwnProperty('$httpStatus') && (resource.$httpStatus < 200 || resource.$httpStatus >= 300)) {
@@ -601,7 +600,8 @@ var resolveSymlinks = function(results, connection, props) {
                     paths.push(key);
                 }
 
-                if (_.has(value, '$link')) {
+                // Use duck typing to see the value can be resolved like a Symlink
+                if (value && typeof value.resolve === 'function') {
                     var path = paths.join('');
                     childProps = props.filter(function filterSelfOnly(prop) {
                         return prop.indexOf(path) === 0;
@@ -615,7 +615,7 @@ var resolveSymlinks = function(results, connection, props) {
                         return prop && prop[0] !== '$' && prop !== key;
                     });
 
-                    var promise = connection.get(value.$link, { props: childProps })
+                    var promise = value.resolve(connection, { props: childProps })
                     .then(function(result) {
                         results[i] = result;
                     });

--- a/lib/Symlink.js
+++ b/lib/Symlink.js
@@ -9,10 +9,10 @@ function Symlink(link) {
     });
 }
 
-Symlink.prototype.resolve = function(connection) {
+Symlink.prototype.resolve = function(connection, options) {
     return this.mutators.reduce(function(prev, mutator) {
         return prev[mutator.type](mutator.handler);
-    }, connection.get(this.$link));
+    }, connection.get(this.$link, options || {}));
 };
 
 Symlink.prototype.then = function(handler) {

--- a/lib/util/merge.js
+++ b/lib/util/merge.js
@@ -1,0 +1,49 @@
+'use strict';
+
+var debug = require('debug')('monocle-api:util:merge');
+
+/**
+ * Deeply merges all arguments into one and returns the result.
+ * Objects are simply combined
+ * Arrays values are also merged according to index
+ *
+ * @return merged object/array
+ */
+var merge = module.exports = function(/* obj1, obj2, obj3 */) {
+    if (arguments.length === 0) {
+        debug('nothing to merge, no arguments');
+        return undefined;
+    }
+
+    if (arguments.length === 1) {
+        debug('nothing to merge, only one argument');
+        return arguments[0];
+    }
+
+    var target = arguments[0];
+
+    // convert arguments to array and cut off target object
+    var args = Array.prototype.slice.call(arguments, 1);
+
+    args.forEach(function(obj) {
+        if (typeof obj !== 'object' || obj === null) {
+            debug('source is not an object, replacing target');
+            target = obj;
+            return;
+        }
+
+        Object.keys(obj).forEach(function(key) {
+            if (typeof target[key] !== 'undefined' && typeof obj[key] === 'object' && obj[key] !== null) {
+                debug('deep merging', key);
+                // object, deep merge!
+                target[key] = merge(target[key], obj[key]);
+                return;
+            }
+
+            debug('replacing value in target', key);
+            target[key] = obj[key];
+        });
+    });
+
+    return target;
+};

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "bluebird": "2.9.34",
     "busboy": "0.2.12",
+    "debug": "2.2.0",
     "jade": "1.11.0",
     "jsen": "0.6.0",
     "lodash": "3.10.1",

--- a/test/lib/Router_test.js
+++ b/test/lib/Router_test.js
@@ -71,7 +71,7 @@ describe('API Router', function() {
             this.clock.restore();
         });
 
-        describe('Connects to a resource with get parameters', function() {
+        describe('connects to a resource with get parameters', function() {
             beforeEach(function() {
                 this.getParamsFoo = sinon.spy(function(request, connection) {
                     return {

--- a/test/lib/util/merge_test.js
+++ b/test/lib/util/merge_test.js
@@ -1,0 +1,220 @@
+var merge = require(LIB_DIR + '/util/merge');
+
+describe('util: merge', function() {
+    describe('with no arguments', function() {
+        it('returns `undefined`', function() {
+            expect(merge()).to.be.undefined;
+        });
+    });
+
+    describe('with 1 argument', function() {
+        [
+            { foo: 'test foo', bar: 'test bar' },
+            [ 'foo', 'bar' ],
+            'foobar'
+        ].forEach(function(value) {
+            it('returns argument unchanged with value ' + JSON.stringify(value), function() {
+                merge(value).should.equal(value);
+            });
+        });
+    });
+
+    describe('with 2 arguments', function() {
+        describe('simple objects', function() {
+            it('merges properties from b into a', function() {
+                var a = { foo: 'test foo' };
+                var b = { bar: 'test bar' };
+                var result = merge(a, b);
+                result.should.have.property('foo', 'test foo');
+                result.should.have.property('bar', 'test bar');
+            });
+
+            it('overwrites existing key in a with value from b', function() {
+                var a = { foo: 'test foo' };
+                var b = { foo: 'different foo' };
+                var result = merge(a, b);
+                result.should.have.property('foo', 'different foo');
+            });
+        });
+
+        describe('object instances', function() {
+            beforeEach(function() {
+                this.Thing = function(name) {
+                    this.name = name;
+                };
+                this.Thing.prototype.say = function(message) {
+                    return this.name + ' says ' + message;
+                };
+            });
+
+            it('keeps prototype methods', function() {
+                var a = new this.Thing('a');
+                var b = new this.Thing('b');
+                var result = merge(a, b);
+                result.say.should.be.a('function');
+                result.say('hi').should.equal('b says hi');
+            });
+
+            it('keeps class type', function() {
+                var a = new this.Thing('a');
+                var b = new this.Thing('b');
+                var result = merge(a, b);
+                result.should.be.instanceOf(this.Thing);
+            });
+        });
+
+        describe('deep objects', function() {
+            it('merges deep properties', function() {
+                var a = {
+                    foo: {
+                        bar: {
+                            derp: 'test derp'
+                        }
+                    }
+                };
+                var b = {
+                    foo: {
+                        bar: {
+                            flerp: 'test flerp'
+                        }
+                    }
+                };
+                var result = merge(a, b);
+                result.should.deep.equal({
+                    foo: {
+                        bar: {
+                            derp: 'test derp',
+                            flerp: 'test flerp'
+                        }
+                    }
+                });
+            });
+        });
+
+        describe('arrays', function() {
+            it('merges values by index', function() {
+                var a = [
+                    { foo: 'a foo 1', bar: 'a bar 1' },
+                    { foo: 'a foo 2' },
+                    { foo: 'a foo 3' }
+                ];
+                var b = [
+                    { foo: 'b foo 1', bar: 'b bar 1' },
+                    { foo: 'b foo 2' },
+                    { bar: 'b bar 3' }
+                ];
+                var result = merge(a, b);
+                result.should.have.lengthOf(3);
+                result.should.be.an('array');
+                result[0].should.deep.equal({ foo: 'b foo 1', bar: 'b bar 1' });
+                result[1].should.deep.equal({ foo: 'b foo 2' });
+                result[2].should.deep.equal({ foo: 'a foo 3', bar: 'b bar 3' });
+            });
+        });
+
+        describe('complex objects', function() {
+            it('merges objects deeply including arrays', function() {
+                var usersA = {
+                    total: 20,
+                    items: [
+                        {
+                            displayName: 'Alice',
+                            age: 30,
+                            lastOnline: new Date(1000),
+                            favoriteColors: [ 'red', 'pink' ]
+                        },
+                        {
+                            displayName: 'Jane',
+                            age: 23,
+                            lastOnline: new Date(2000),
+                            favoriteColors: [ 'blue' ]
+                        }
+                    ]
+                };
+
+                var usersB = {
+                    items: [
+                        {
+                            email: 'alice@example.com',
+                            emailValidated: true,
+                            photo: {
+                                url: '/alice.jpg'
+                            }
+                        },
+                        {
+                            email: 'jane@example.com',
+                            emailValidated: false,
+                            photo: {
+                                url: '/jane.jpg'
+                            }
+                        }
+                    ]
+                };
+
+                var result = merge(usersA, usersB);
+                result.should.have.property('total', 20);
+                result.items.should.have.lengthOf(2);
+
+                // Validate first user merged properly
+                result.items[0].should.have.property('displayName', 'Alice');
+                result.items[0].should.have.property('age', 30);
+                result.items[0].should.have.property('lastOnline');
+                result.items[0].lastOnline.getTime().should.equal(new Date(1000).getTime());
+                result.items[0].should.have.property('favoriteColors');
+                result.items[0].favoriteColors.should.have.lengthOf(2);
+                result.items[0].favoriteColors.should.contain('red');
+                result.items[0].favoriteColors.should.contain('pink');
+                result.items[0].should.have.property('emailValidated', true);
+                result.items[0].should.have.property('email', 'alice@example.com');
+                result.items[0].should.have.property('photo');
+                result.items[0].photo.should.deep.equal({ url: '/alice.jpg' });
+
+                // Validate second user merged properly
+                result.items[1].should.have.property('displayName', 'Jane');
+                result.items[1].should.have.property('age', 23);
+                result.items[1].should.have.property('lastOnline');
+                result.items[1].lastOnline.getTime().should.equal(new Date(2000).getTime());
+                result.items[1].should.have.property('favoriteColors');
+                result.items[1].favoriteColors.should.have.lengthOf(1);
+                result.items[1].favoriteColors.should.contain('blue');
+                result.items[1].should.have.property('emailValidated', false);
+                result.items[1].should.have.property('email', 'jane@example.com');
+                result.items[1].should.have.property('photo');
+                result.items[1].photo.should.deep.equal({ url: '/jane.jpg' });
+            });
+        });
+    });
+
+    describe('with many arguments', function() {
+        it('merges all of them, with last value overriding previous ones', function() {
+            var result = merge(
+                { foo: 'foo 0', bar: 'bar 0', derp: 'derp 0' },
+                { foo: 'foo 1' },
+                { bar: 'bar 2', derp: 'derp 2' },
+                { haz: 'haz 3', derp: 'derp 3' }
+            );
+            result.should.deep.equal({
+                foo: 'foo 1',
+                bar: 'bar 2',
+                derp: 'derp 3',
+                haz: 'haz 3'
+            });
+        });
+    });
+
+    describe('with non-objects', function() {
+        [
+            [ 'foo' ],
+            [ 'foo', 'bar' ],
+            [ true, false ],
+            [ 'a', 'b', 'c', 'd', 'e'],
+            [ { foo: 'foo' }, null ],
+            [ 1, NaN, 2, undefined, 0.4, true, 'foo', Infinity ]
+        ].forEach(function(args) {
+            var expectedResult = args[args.length - 1];
+            it('returns ' + JSON.stringify(expectedResult) + ' from arguments ' + JSON.stringify(args), function() {
+                expect(merge.apply(this, args)).to.equal(expectedResult);
+            });
+        });
+    });
+});


### PR DESCRIPTION
Delegates symlink resolution to `Symlink#resolve` to allow chained resolvers to be executed.

This required writing a custom `merge()` function because lodash's `_.merge()` kills all prototype values when merging. I also looked at the popular `deep-extend` module, but it had weak support for arrays.
