### PR TITLE
WTF-16259 Add support for aliases

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -312,6 +312,22 @@ app.use(function(req, res, next) {
     res.end();
 });
 
+/*** Set up some aliases ***/
+api.alias('/alice', '/users/1');
+
+/*** Set up some aliases ***/
+api.alias('/random', function(request, connection) {
+    var userId = Math.ceil(Math.random() * mockUserBasicInfo.length);
+    request.setResourceId('/users/' + userId);
+    return request;
+});
+
+/*** Set up some aliases ***/
+api.alias('/me', function(request, connection) {
+    request.setResourceId('/users/2');
+    return request;
+});
+
 // Allow uploaded files to be served
 var serveStatic = require('serve-static');
 app.use(serveStatic(path.join(__dirname, 'files')));

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -1,4 +1,5 @@
 var Request = require('./Request');
+var debug = require('debug')('monocle-api:connection');
 
 module.exports = Connection;
 
@@ -9,7 +10,7 @@ function Connection(router, req, res) {
     this.raw = {
         req: req,
         res: res
-    }
+    };
 }
 
 // Support various HTTP methods by calling Router's handle method.
@@ -22,6 +23,7 @@ function Connection(router, req, res) {
     Request.METHOD_OPTIONS
 ].forEach(function(method) {
     Connection.prototype[method.toLowerCase()] = function (resourceId, options) {
+        debug('Incoming request', method, resourceId, options)
         var request = new Request(resourceId, this.router, this);
         request.setResourceId(resourceId);
         request.setMethod(method);

--- a/lib/Request.js
+++ b/lib/Request.js
@@ -2,7 +2,6 @@ var libUrl = require('url');
 var _ = require('lodash');
 var SchemaFilter = require('./SchemaFilter');
 var Resource = require('./Resource');
-var validationErrors = require('./models/validationErrors');
 var jsen = require('jsen');
 var Busboy = require('busboy');
 var Promise = require('bluebird');

--- a/lib/Router.js
+++ b/lib/Router.js
@@ -11,7 +11,6 @@ var Symlink = require('./Symlink');
 var PropertyFilter = require('./PropertyFilter');
 var util = require('util');
 var errorSchema = require('./schemas/error');
-var validationErrors = require('./models/validationErrors');
 var Resource = require('./Resource');
 var OffsetPaginator = require('./OffsetPaginator');
 var CollectionCache = require('./CollectionCache');
@@ -86,8 +85,46 @@ Router.prototype.route = function(patternConfig, schema, handlers) {
     return this;
 };
 
+function parsePatternConfig(patternConfig) {
+    var pattern;
+    var query;
+
+    if (Array.isArray(patternConfig)) {
+        pattern = patternConfig[0];
+        query = querystring.parse(patternConfig[1]);
+    } else {
+        pattern = patternConfig;
+        query = {};
+    }
+
+        // Generate a regex to match URLs
+    var keys = [];
+    var regex = pathToRegexp(pattern, keys); // keys are passed in by reference
+
+    return {
+        pattern: pattern,
+        query: query,
+        regex: regex,
+        keys: keys
+    };
+}
+
 Router.prototype.postRoute = function(callback) {
     this._postRoutes.push(callback);
+    return this;
+};
+
+Router.prototype.alias = function(patternConfig, aliasResolver) {
+    var parsedPattern = parsePatternConfig(patternConfig);
+
+    this._routes.push({
+        pattern: parsedPattern.pattern,
+        query: parsedPattern.query,
+        regex: parsedPattern.regex,
+        keys: parsedPattern.keys,
+        aliasResolver: aliasResolver
+    });
+
     return this;
 };
 
@@ -96,10 +133,8 @@ var sortByTitle = function(docs) {
 };
 
 var titleCompare = function(a, b) {
-    return (a.schema.title || a.pattern) > (b.schema.title || b.pattern);
+    return ((a.schema && a.schema.title) || a.pattern) > ((b.schema && b.schema.title) || b.pattern);
 };
-
-
 
 Router.prototype.documentAll = function() {
     return Promise.map(this._routes, documentRoute)
@@ -107,29 +142,39 @@ Router.prototype.documentAll = function() {
 };
 
 function documentRoute(route) {
-    // OPTIONS are always supported
-    var methods = Object.keys(route.handlers).concat([Request.METHOD_OPTIONS]).sort(function(a, b) {
-        var valueOf = function(method) {
-            var values = {
-                GET: -10e6,
-                POST: -10e5,
-                PUT: -10e4,
-                PATCH: -10e3,
-                DELETE: -10e2,
-                OPTIONS: -10e1
+    var alias;
+    var methods;
+
+    if (route.aliasResolver) {
+        debug('documenting alias', route);
+        alias = (typeof route.aliasResolver === 'string') ? route.aliasResolver : '<dynamic>';
+    } else {
+        debug('documenting route', route);
+        // OPTIONS are always supported
+        methods = Object.keys(route.handlers).concat([Request.METHOD_OPTIONS]).sort(function(a, b) {
+            var valueOf = function(method) {
+                var values = {
+                    GET: -10e6,
+                    POST: -10e5,
+                    PUT: -10e4,
+                    PATCH: -10e3,
+                    DELETE: -10e2,
+                    OPTIONS: -10e1
+                }
+
+                return (values.hasOwnProperty(method)) ? values[method] : 0;
             }
 
-            return (values.hasOwnProperty(method)) ? values[method] : 0;
-        }
-
-        return (valueOf(a) < valueOf(b)) ? -1 : 1;
-    });
+            return (valueOf(a) < valueOf(b)) ? -1 : 1;
+        });
+    }
 
     return Promise.resolve({
         pattern: route.pattern,
         methods: methods,
         query: route.query,
-        schema: route.schema
+        schema: route.schema,
+        alias: alias
     });
 };
 
@@ -192,6 +237,34 @@ Router.prototype.handle = function(request, connection) {
 
     var match = matched.match;
     route = matched.route;
+
+    if (route.aliasResolver) {
+        // route is an alias, resolve the alias and handle the modified request
+        var target;
+        var originalResourceId = request.getResourceId();
+
+        if (typeof route.aliasResolver === 'function') {
+            target = Promise.resolve(route.aliasResolver(request, connection));
+        } else if (typeof route.aliasResolver === 'string') {
+            request.setResourceId(route.aliasResolver);
+            target = Promise.resolve(request);
+        }
+
+        return target.then(function(targetRequest) {
+            if (!targetRequest || typeof targetRequest.getResourceId !== 'function') {
+                debug('Alias did not resolve to a Request instance', originalResourceId, typeof targetRequest);
+                return request.error(500, 'Alias did not resolve to a Request instance');
+            }
+
+            if (targetRequest.getResourceId() === originalResourceId) {
+                debug('Alias pointed back to itself', originalResourceId);
+                return request.error(508, 'Alias pointed back to itself');
+            }
+
+            debug('Resolving alias', targetRequest.getResourceId());
+            return this.handle(targetRequest, connection);
+        }.bind(this));
+    }
 
     // Support OPTIONS
     if (request.isOptions()) {

--- a/lib/views/docs.jade
+++ b/lib/views/docs.jade
@@ -111,6 +111,15 @@ mixin resource(pattern, schema, methods, query)
         section.items
             +resource(null, schema.items, null)
 
+mixin alias(pattern, alias)
+    h2
+        = '* ' + pattern
+        span(class="type type-alias") alias
+
+    h3.alias
+        = 'Points to '
+        span.alias= alias
+
 doctype html
 html
     head
@@ -128,7 +137,10 @@ html
 
             ul
                 each route in routes
-                    li: a(href="##{route.pattern}")= route.schema.title || route.pattern
+                    li: a(href="##{route.pattern}")
+                        if route.alias
+                            = '* '
+                        = (route.schema && route.schema.title) || route.pattern
 
         .resources
             each route in routes
@@ -136,10 +148,14 @@ html
                 - schema = route.schema
                 - methods = route.methods
                 - query = route.query
-                .resource(id=route.pattern)
-                    +resource(pattern, schema, methods, query)
+                - alias = route.alias
 
-                    h3.sample Sample Response:
-                    pre.response= JSON.stringify(mockValue(schema), null, 2)
+                .resource(id=route.pattern)
+                    if route.alias
+                        +alias(pattern, alias)
+                    else
+                        +resource(pattern, schema, methods, query)
+                        h3.sample Sample Response:
+                        pre.response= JSON.stringify(mockValue(schema), null, 2)
 
                     div: a(href="#") Back to Top

--- a/lib/views/styles.css
+++ b/lib/views/styles.css
@@ -224,6 +224,14 @@ span.type-integer{
     background: #c81;
 }
 
+span.type-alias{
+    background: #249;
+}
+
+span.alias{
+    font-family: monaco, monospace;
+}
+
 h2 span.type{
     vertical-align: top;
 }


### PR DESCRIPTION
This adds the ability to register aliases for resources, including the ability to dynamically resolve the alias on a per-request basis.

**Usage**

``` js
// Simple string aliases
router.route('/users/:userId', userSchema, methodHandlers);
router.alias('/john', '/users/123'); // Points `/john` to the resource at `/users/123`

// Dynamic aliases allow you to return a modified request
router.alias('/random', function(request, connection) {
  var userId = Math.ceil(Math.random() * 1000);
  request.setResourceId('/users/' + userId);
  return request;
});

// Dynamic aliases can also be asynchronous.
// Simply return a promise that resolves with the modified request
router.alias('/me', function(request, connection) {
  return myUserService.getSessionFromCookies(connection.raw.req.cookies)
  .then(function(session) {
    request.setResourceId('/users/' + session.userId);
    return request;
  });
});
```

**Documentation Updates**

![screen shot 2016-04-07 at 2 30 57 pm](https://cloud.githubusercontent.com/assets/308786/14367581/a205a100-fccd-11e5-8701-a2d3928d6c03.png)

![screen shot 2016-04-07 at 2 31 32 pm](https://cloud.githubusercontent.com/assets/308786/14367585/a8b330bc-fccd-11e5-8e02-e2d3d8e20c23.png)
