### PR TITLE
Use Object.prototype.hasOwnProperty instead of obj.hasOwnProperty

### DIFF
--- a/lib/Request.js
+++ b/lib/Request.js
@@ -153,7 +153,7 @@ Request.prototype.setParam = function(param, value) {
 };
 
 Request.prototype.getParam = function(param) {
-    return this._params.hasOwnProperty(param) ? this._params[param] : undefined;
+    return Object.prototype.hasOwnProperty.call(this._params, param) ? this._params[param] : undefined;
 };
 
 Request.prototype.setQueries = function(queries) {
@@ -177,7 +177,7 @@ Request.prototype.unsetQuery = function(query) {
 };
 
 Request.prototype.getQuery = function(query) {
-    return this._url.query.hasOwnProperty(query) ? this._url.query[query] : undefined;
+    return Object.prototype.hasOwnProperty.call(this._url.query, query) ? this._url.query[query] : undefined;
 };
 
 Request.prototype.setResourceId = function(resourceId) {

--- a/lib/RequestRouter.js
+++ b/lib/RequestRouter.js
@@ -41,7 +41,7 @@ function RequestRouter(request, route, connection) {
 
         //Remove queries that are not set in the route
         for (var key in queries) {
-            if (!route.query.hasOwnProperty(key)) {
+            if (!Object.prototype.hasOwnProperty.call(route.query, key)) {
                 delete queries[key];
             }
         }
@@ -148,7 +148,7 @@ RequestRouter.prototype.setParam = function(key, value) {
     this._request.setParam(key, value);
     var returnParam = validateAndCast.call(this, {key : value});
 
-    if (returnParam && returnParam.hasOwnProperty(key)) {
+    if (returnParam && Object.prototype.hasOwnProperty.call(returnParam, key)) {
         this._request.setParam(key, returnParam[key]);
     }
 
@@ -177,7 +177,7 @@ RequestRouter.prototype.setQuery = function(key, value) {
     this._request.setQuery(key, value);
     var returnQuery = validateAndCast.call(this, {key : value});
 
-    if (returnQuery && returnQuery.hasOwnProperty(key)) {
+    if (returnQuery && Object.prototype.hasOwnProperty.call(returnQuery, key)) {
         this._request.setQuery(key, returnQuery[key]);
     }
     return this;
@@ -283,7 +283,7 @@ function validateAndCastObject(object, schema, parentKey) {
     }
 
     for (var key in object) {
-        if (!object.hasOwnProperty(key) || key[0].indexOf('$') !== -1) {
+        if (!Object.prototype.hasOwnProperty.call(object, key) || key[0].indexOf('$') !== -1) {
             continue;
         }
 


### PR DESCRIPTION
This may be undefined, or the object prototype may not include Object.
This problem was encountered with newer node version(6) or upgraded dependencies.

Fixes `TypeError: object.hasOwnProperty is not a function`

https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#querystring is likely to be the cause of this issue.