### PR TITLE
STREAM-1751 Allow usage of `props` to fetch more data after a `PATCH`…

### DIFF
--- a/lib/Router.js
+++ b/lib/Router.js
@@ -360,7 +360,16 @@ Router.prototype.handle = function(request, connection) {
 
         var props = requestRouter.getProps();
 
-        // Restrict by props before resolving symlinks to delete symlinks that are not needed.
+        if (-1 !== [Request.METHOD_PATCH, Request.METHOD_PUT].indexOf(method)) {
+            debug('Converting to symlink to help resolve props');
+            return new Symlink(resourceId, result).resolve(connection, { props: request.getProps(), query: request.getQuery() });
+        }
+
+        return result;
+    })
+    .then(function(result) {
+        var props = request.getProps();
+        // Restrict by props before resolving embedded symlinks to delete symlinks that are not needed.
         result = restrictProps(result, props);
 
         // Support internal errors


### PR DESCRIPTION
… or `PUT`

When making a `PATCH` or `PUT` request, only the properties that are found on the submitted resource will affect how the request is routed (i.e. `props` is ignore for initial routing on these requests). Once the operation has completed successfully, the `props` value is used to determine which information is sent back in the response. If the `PATCH` or `PUT` handlers were unable to provide all of the data requested by `props`, an internal GET call is made to the resource.

```
> PATCH /users/123?props=displayName,age
> {
>   "displayName": "Hector V."
> }

// Only the PATCH callback for `displayName` is executed, but the response now also contains the requested `age` prop.

< HTTP/1.1 200 OK
< ...
<
< {
<   "displayName": "Hector V.", // value provided by internal PATCH call
<   "age": 35,                  // value provided by making a GET internally
< }

```