### PR TITLE
Fix a bug causing Monocle.Collection to be undefined.

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -2,8 +2,6 @@ var Request = require('./Request');
 var debug = require('debug')('monocle-api:connection');
 var querystring = require('querystring');
 
-module.exports = Connection;
-
 // A Connection object holds a Router instance, and raw HTTP request and response object.
 // It can be used to initiate another request.
 function Connection(router, req, res) {
@@ -57,3 +55,5 @@ function Connection(router, req, res) {
         return this.router.handle(request, this); // pass self to router's handler
     }
 });
+
+module.exports = Connection;


### PR DESCRIPTION
This happened when using node 8.
This happened because the function was not yet defined.

After this PR, `require('./lib/Connection.js')` returns a Function